### PR TITLE
Make default node red

### DIFF
--- a/src/contracts/utils/red_black_tree.cairo
+++ b/src/contracts/utils/red_black_tree.cairo
@@ -62,8 +62,8 @@ pub mod RBTreeComponent {
             let new_node_id = value.id;
 
             if self.root.read() == 0 {
-                self.root.write(new_node_id);
                 self.tree.write(new_node_id, self.create_default_node(@value));
+                self.root.write(new_node_id);
                 return;
             }
 
@@ -235,7 +235,15 @@ pub mod RBTreeComponent {
         }
 
         fn create_default_node(self: @ComponentState<TContractState>, value: @Bid) -> Node {
-            Node { value: *value, left: 0, right: 0, parent: 0, color: BLACK, }
+            // If the tree is non-empty, the newly inserted node is red
+            let mut color = RED;
+
+            // If the tree is empty, the root node is black
+            if self.root.read() == 0 {
+                color = BLACK;
+            }
+
+            Node { value: *value, left: 0, right: 0, parent: 0, color: color, }
         }
 
         fn is_left_child(ref self: ComponentState<TContractState>, node_id: felt252) -> bool {

--- a/src/contracts/utils/red_black_tree.cairo
+++ b/src/contracts/utils/red_black_tree.cairo
@@ -62,6 +62,8 @@ pub mod RBTreeComponent {
             let new_node_id = value.id;
 
             if self.root.read() == 0 {
+                // Root should be written after the first insertion
+                // as we expect the root to be 0 in the beginning
                 self.tree.write(new_node_id, self.create_default_node(@value));
                 self.root.write(new_node_id);
                 return;


### PR DESCRIPTION
When we insert a node and the tree is empty, it's the root node that we insert and it should be black. If the tree is nonempty, the node that we add should be red. This condition was missed when migrating the tree to a component.

The reason test cases are passing even though we don't have this condition is because, the elements that we insert into the tree will be present in the tree and we can retrieve them back, but the tree might not be properly balanced.