### PR TITLE
New node inserted should be red

### DIFF
--- a/src/contracts/utils/red_black_tree.cairo
+++ b/src/contracts/utils/red_black_tree.cairo
@@ -193,7 +193,7 @@ pub mod RBTreeComponent {
 
                     // update parent
                     let new_node = Node {
-                        left: 0, right: 0, value, parent: current_id, color: BLACK
+                        left: 0, right: 0, value, parent: current_id, color: RED
                     };
                     self.tree.write(new_node_id, new_node);
                     self.tree.write(current_id, current_node);
@@ -208,7 +208,7 @@ pub mod RBTreeComponent {
 
                     // update parent
                     let new_node = Node {
-                        left: 0, right: 0, value, parent: current_id, color: BLACK
+                        left: 0, right: 0, value, parent: current_id, color: RED
                     };
                     self.tree.write(new_node_id, new_node);
                     self.tree.write(current_id, current_node);


### PR DESCRIPTION
The new nodes inserted should be `RED`. Only when tree is empty, we insert the new node as `BLACK`.

NB - Test case is passing even though this issue is there might be because the elements are present in the tree, but the tree might not be properly balanced.