### PR TITLE
Refine rb tree tests

### DIFF
--- a/.github/workflows/rb_tree_tests.yaml
+++ b/.github/workflows/rb_tree_tests.yaml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
     branches:
-      - "**"
+      - main
     types:
       - reopened
       - ready_for_review

--- a/src/tests/option_round/rb_tree/rb_tree_mock_contract.cairo
+++ b/src/tests/option_round/rb_tree/rb_tree_mock_contract.cairo
@@ -1,5 +1,3 @@
-use pitch_lake_starknet::{contracts::{option_round::{types::{Bid}}}};
-
 #[starknet::contract]
 mod RBTreeMockContract {
     use pitch_lake_starknet::contracts::components::red_black_tree::RBTreeComponent;

--- a/src/tests/option_round/rb_tree/rb_tree_mock_contract.cairo
+++ b/src/tests/option_round/rb_tree/rb_tree_mock_contract.cairo
@@ -1,15 +1,5 @@
 use pitch_lake_starknet::{contracts::{option_round::{types::{Bid}}}};
 
-#[starknet::interface]
-pub trait IRBTreeMockContract<TContractState> {
-    fn insert(ref self: TContractState, value: Bid);
-    fn find(self: @TContractState, bid_id: felt252) -> Bid;
-    fn get_tree_structure(self: @TContractState) -> Array<Array<(u256, bool, u128)>>;
-    fn is_tree_valid(self: @TContractState) -> bool;
-    fn delete(ref self: TContractState, bid_id: felt252);
-    fn add_node(ref self: TContractState, value: Bid, color: bool, parent: felt252) -> felt252;
-}
-
 #[starknet::contract]
 mod RBTreeMockContract {
     use pitch_lake_starknet::contracts::components::red_black_tree::RBTreeComponent;

--- a/src/tests/option_round/rb_tree/rb_tree_mock_contract.cairo
+++ b/src/tests/option_round/rb_tree/rb_tree_mock_contract.cairo
@@ -1,3 +1,15 @@
+use pitch_lake_starknet::{contracts::{option_round::{types::{Bid}}}};
+
+#[starknet::interface]
+pub trait IRBTreeMockContract<TContractState> {
+    fn insert(ref self: TContractState, value: Bid);
+    fn find(self: @TContractState, bid_id: felt252) -> Bid;
+    fn get_tree_structure(self: @TContractState) -> Array<Array<(u256, bool, u128)>>;
+    fn is_tree_valid(self: @TContractState) -> bool;
+    fn delete(ref self: TContractState, bid_id: felt252);
+    fn add_node(ref self: TContractState, value: Bid, color: bool, parent: felt252) -> felt252;
+}
+
 #[starknet::contract]
 mod RBTreeMockContract {
     use pitch_lake_starknet::contracts::components::red_black_tree::RBTreeComponent;

--- a/src/tests/option_round/rb_tree/rb_tree_stress_tests.cairo
+++ b/src/tests/option_round/rb_tree/rb_tree_stress_tests.cairo
@@ -2,7 +2,8 @@ use pitch_lake_starknet::{
     tests::{
         utils::helpers::setup::setup_rb_tree_test,
         option_round::rb_tree::rb_tree_tests::{
-            IRBTreeDispatcherTrait, insert, mock_address, MOCK_ADDRESS, delete, create_bid
+            IRBTreeMockContractDispatcherTrait,
+            insert, mock_address, MOCK_ADDRESS, delete, create_bid
         },
     },
     contracts::option_round::types::Bid,

--- a/src/tests/option_round/rb_tree/rb_tree_stress_tests.cairo
+++ b/src/tests/option_round/rb_tree/rb_tree_stress_tests.cairo
@@ -2,8 +2,8 @@ use pitch_lake_starknet::{
     tests::{
         utils::helpers::setup::setup_rb_tree_test,
         option_round::rb_tree::rb_tree_tests::{
-            IRBTreeMockContractDispatcherTrait,
-            insert, mock_address, MOCK_ADDRESS, delete, create_bid
+            IRBTreeMockContractDispatcherTrait, insert, mock_address, MOCK_ADDRESS, delete,
+            create_bid
         },
     },
     contracts::option_round::types::Bid,

--- a/src/tests/option_round/rb_tree/rb_tree_stress_tests.cairo
+++ b/src/tests/option_round/rb_tree/rb_tree_stress_tests.cairo
@@ -2,11 +2,13 @@ use pitch_lake_starknet::{
     tests::{
         utils::helpers::setup::setup_rb_tree_test,
         option_round::rb_tree::rb_tree_tests::{
-            IRBTreeMockContractDispatcherTrait, insert, mock_address, MOCK_ADDRESS, delete,
-            create_bid
+            insert, mock_address, MOCK_ADDRESS, delete, create_bid
         },
     },
-    contracts::option_round::types::Bid,
+    contracts::{
+        option_round::types::Bid,
+        components::red_black_tree::{IRBTreeDispatcher, IRBTreeDispatcherTrait}
+    },
 };
 use core::pedersen::pedersen;
 

--- a/src/tests/option_round/rb_tree/rb_tree_tests.cairo
+++ b/src/tests/option_round/rb_tree/rb_tree_tests.cairo
@@ -1,7 +1,10 @@
 use core::traits::TryInto;
 use pitch_lake_starknet::{
-    tests::option_round::{rb_tree::rb_tree_mock_contract::RBTreeMockContract},
+    tests::{option_round::{rb_tree::rb_tree_mock_contract::{RBTreeMockContract, IRBTreeMockContractDispatcher,IRBTreeMockContractDispatcherTrait}},
+
+    },
     contracts::option_round::types::Bid,
+
 };
 use starknet::{contract_address_const, ContractAddress};
 use core::pedersen::pedersen;
@@ -11,15 +14,15 @@ const RED: bool = true;
 
 const MOCK_ADDRESS: felt252 = 123456;
 
-#[starknet::interface]
-pub trait IRBTree<TContractState> {
-    fn insert(ref self: TContractState, value: Bid);
-    fn find(self: @TContractState, bid_id: felt252) -> Bid;
-    fn get_tree_structure(self: @TContractState) -> Array<Array<(u256, bool, u128)>>;
-    fn is_tree_valid(self: @TContractState) -> bool;
-    fn delete(ref self: TContractState, bid_id: felt252);
-    fn add_node(ref self: TContractState, value: Bid, color: bool, parent: felt252) -> felt252;
-}
+//#[starknet::interface]
+//pub trait IRBTree<TContractState> {
+//    fn insert(ref self: TContractState, value: Bid);
+//    fn find(self: @TContractState, bid_id: felt252) -> Bid;
+//    fn get_tree_structure(self: @TContractState) -> Array<Array<(u256, bool, u128)>>;
+//    fn is_tree_valid(self: @TContractState) -> bool;
+//    fn delete(ref self: TContractState, bid_id: felt252);
+//    fn add_node(ref self: TContractState, value: Bid, color: bool, parent: felt252) -> felt252;
+//}
 
 fn mock_address(value: felt252) -> ContractAddress {
     contract_address_const::<'liquidity_provider_1'>()
@@ -1197,7 +1200,7 @@ fn test_mirror_deletion_black_node_successor() {
 
 #[test]
 fn test_delete_tree_one_by_one() {
-    let rb_tree = setup_rb_tree_test();
+    let rb_tree= setup_rb_tree_test();
 
     let node_90 = insert(rb_tree, 90, 1);
     let node_70 = insert(rb_tree, 70, 2);
@@ -1246,7 +1249,7 @@ fn create_bid(price: u256, nonce: u64) -> Bid {
     }
 }
 
-fn insert(rb_tree: IRBTreeDispatcher, price: u256, nonce: u64) -> felt252 {
+fn insert(rb_tree: IRBTreeMockContractDispatcher, price: u256, nonce: u64) -> felt252 {
     let bidder = mock_address(MOCK_ADDRESS);
     let id = poseidon::poseidon_hash_span(array![bidder.into(), nonce.try_into().unwrap()].span());
     rb_tree
@@ -1264,12 +1267,12 @@ fn insert(rb_tree: IRBTreeDispatcher, price: u256, nonce: u64) -> felt252 {
     return id;
 }
 
-fn is_tree_valid(rb_tree: IRBTreeDispatcher) {
+fn is_tree_valid(rb_tree: IRBTreeMockContractDispatcher){
     let is_tree_valid = rb_tree.is_tree_valid();
 //println!("Is tree valid: {:?}", is_tree_valid);
 }
 
-fn delete(rb_tree: IRBTreeDispatcher, bid_id: felt252) {
+fn delete(rb_tree: IRBTreeMockContractDispatcher, bid_id: felt252) {
     rb_tree.delete(bid_id);
 }
 

--- a/src/tests/option_round/rb_tree/rb_tree_tests.cairo
+++ b/src/tests/option_round/rb_tree/rb_tree_tests.cairo
@@ -1,12 +1,5 @@
 use core::traits::TryInto;
 use pitch_lake_starknet::{
-    tests::{
-        option_round::{
-            rb_tree::rb_tree_mock_contract::{ //RBTreeMockContract, IRBTreeMockContractDispatcher,
-            //IRBTreeMockContractDispatcherTrait
-            }
-        },
-    },
     contracts::{
         option_round::{types::{Bid}},
         components::{red_black_tree::{IRBTreeDispatcher, IRBTreeDispatcherTrait}},

--- a/src/tests/option_round/rb_tree/rb_tree_tests.cairo
+++ b/src/tests/option_round/rb_tree/rb_tree_tests.cairo
@@ -1,10 +1,14 @@
 use core::traits::TryInto;
 use pitch_lake_starknet::{
-    tests::{option_round::{rb_tree::rb_tree_mock_contract::{RBTreeMockContract, IRBTreeMockContractDispatcher,IRBTreeMockContractDispatcherTrait}},
-
+    tests::{
+        option_round::{
+            rb_tree::rb_tree_mock_contract::{
+                RBTreeMockContract, IRBTreeMockContractDispatcher,
+                IRBTreeMockContractDispatcherTrait
+            }
+        },
     },
     contracts::option_round::types::Bid,
-
 };
 use starknet::{contract_address_const, ContractAddress};
 use core::pedersen::pedersen;
@@ -1200,7 +1204,7 @@ fn test_mirror_deletion_black_node_successor() {
 
 #[test]
 fn test_delete_tree_one_by_one() {
-    let rb_tree= setup_rb_tree_test();
+    let rb_tree = setup_rb_tree_test();
 
     let node_90 = insert(rb_tree, 90, 1);
     let node_70 = insert(rb_tree, 70, 2);
@@ -1267,7 +1271,7 @@ fn insert(rb_tree: IRBTreeMockContractDispatcher, price: u256, nonce: u64) -> fe
     return id;
 }
 
-fn is_tree_valid(rb_tree: IRBTreeMockContractDispatcher){
+fn is_tree_valid(rb_tree: IRBTreeMockContractDispatcher) {
     let is_tree_valid = rb_tree.is_tree_valid();
 //println!("Is tree valid: {:?}", is_tree_valid);
 }

--- a/src/tests/option_round/rb_tree/rb_tree_tests.cairo
+++ b/src/tests/option_round/rb_tree/rb_tree_tests.cairo
@@ -1271,9 +1271,10 @@ fn insert(rb_tree: IRBTreeMockContractDispatcher, price: u256, nonce: u64) -> fe
     return id;
 }
 
-fn is_tree_valid(rb_tree: IRBTreeMockContractDispatcher) {
+fn is_tree_valid(rb_tree: IRBTreeMockContractDispatcher) -> bool {
     let is_tree_valid = rb_tree.is_tree_valid();
-//println!("Is tree valid: {:?}", is_tree_valid);
+    //println!("Is tree valid: {:?}", is_tree_valid);
+    is_tree_valid
 }
 
 fn delete(rb_tree: IRBTreeMockContractDispatcher, bid_id: felt252) {

--- a/src/tests/option_round/rb_tree/rb_tree_tests.cairo
+++ b/src/tests/option_round/rb_tree/rb_tree_tests.cairo
@@ -2,31 +2,23 @@ use core::traits::TryInto;
 use pitch_lake_starknet::{
     tests::{
         option_round::{
-            rb_tree::rb_tree_mock_contract::{
-                RBTreeMockContract, IRBTreeMockContractDispatcher,
-                IRBTreeMockContractDispatcherTrait
+            rb_tree::rb_tree_mock_contract::{ //RBTreeMockContract, IRBTreeMockContractDispatcher,
+            //IRBTreeMockContractDispatcherTrait
             }
         },
     },
-    contracts::option_round::types::Bid,
+    contracts::{
+        option_round::{types::{Bid}},
+        components::{red_black_tree::{IRBTreeDispatcher, IRBTreeDispatcherTrait}},
+    },
 };
 use starknet::{contract_address_const, ContractAddress};
 use core::pedersen::pedersen;
 use pitch_lake_starknet::tests::utils::helpers::setup::setup_rb_tree_test;
+
 const BLACK: bool = false;
 const RED: bool = true;
-
 const MOCK_ADDRESS: felt252 = 123456;
-
-//#[starknet::interface]
-//pub trait IRBTree<TContractState> {
-//    fn insert(ref self: TContractState, value: Bid);
-//    fn find(self: @TContractState, bid_id: felt252) -> Bid;
-//    fn get_tree_structure(self: @TContractState) -> Array<Array<(u256, bool, u128)>>;
-//    fn is_tree_valid(self: @TContractState) -> bool;
-//    fn delete(ref self: TContractState, bid_id: felt252);
-//    fn add_node(ref self: TContractState, value: Bid, color: bool, parent: felt252) -> felt252;
-//}
 
 fn mock_address(value: felt252) -> ContractAddress {
     contract_address_const::<'liquidity_provider_1'>()
@@ -1253,7 +1245,7 @@ fn create_bid(price: u256, nonce: u64) -> Bid {
     }
 }
 
-fn insert(rb_tree: IRBTreeMockContractDispatcher, price: u256, nonce: u64) -> felt252 {
+fn insert(rb_tree: IRBTreeDispatcher, price: u256, nonce: u64) -> felt252 {
     let bidder = mock_address(MOCK_ADDRESS);
     let id = poseidon::poseidon_hash_span(array![bidder.into(), nonce.try_into().unwrap()].span());
     rb_tree
@@ -1271,13 +1263,13 @@ fn insert(rb_tree: IRBTreeMockContractDispatcher, price: u256, nonce: u64) -> fe
     return id;
 }
 
-fn is_tree_valid(rb_tree: IRBTreeMockContractDispatcher) -> bool {
+fn is_tree_valid(rb_tree: IRBTreeDispatcher) -> bool {
     let is_tree_valid = rb_tree.is_tree_valid();
     //println!("Is tree valid: {:?}", is_tree_valid);
     is_tree_valid
 }
 
-fn delete(rb_tree: IRBTreeMockContractDispatcher, bid_id: felt252) {
+fn delete(rb_tree: IRBTreeDispatcher, bid_id: felt252) {
     rb_tree.delete(bid_id);
 }
 

--- a/src/tests/utils/helpers/setup.cairo
+++ b/src/tests/utils/helpers/setup.cairo
@@ -36,7 +36,8 @@ use pitch_lake_starknet::{
     },
     tests::{
         option_round::rb_tree::{
-            rb_tree_tests::IRBTreeDispatcher, rb_tree_mock_contract::RBTreeMockContract
+            //rb_tree_tests::IRBTreeDispatcher,
+            rb_tree_mock_contract::{RBTreeMockContract, IRBTreeMockContractDispatcher}
         },
         utils::{
             lib::{
@@ -164,12 +165,12 @@ fn deploy_pitch_lake() -> IPitchLakeDispatcher {
     return IPitchLakeDispatcher { contract_address };
 }
 
-fn setup_rb_tree_test() -> IRBTreeDispatcher {
+fn setup_rb_tree_test() -> IRBTreeMockContractDispatcher{
     let (address, _) = deploy_syscall(
         RBTreeMockContract::TEST_CLASS_HASH.try_into().unwrap(), 0, array![].span(), false
     )
         .unwrap_syscall();
-    IRBTreeDispatcher { contract_address: address }
+    IRBTreeMockContractDispatcher { contract_address: address }
 }
 
 fn setup_facade() -> (VaultFacade, ERC20ABIDispatcher) {

--- a/src/tests/utils/helpers/setup.cairo
+++ b/src/tests/utils/helpers/setup.cairo
@@ -12,7 +12,7 @@ use openzeppelin::{
 };
 use pitch_lake_starknet::{
     contracts::{
-        components::eth::Eth,
+        components::{eth::Eth, red_black_tree::{IRBTreeDispatcher, IRBTreeDispatcherTrait}},
         pitch_lake::{
             IPitchLakeDispatcher, IPitchLakeSafeDispatcher, IPitchLakeDispatcherTrait, PitchLake,
             IPitchLakeSafeDispatcherTrait
@@ -35,10 +35,7 @@ use pitch_lake_starknet::{
         },
     },
     tests::{
-        option_round::rb_tree::{
-            //rb_tree_tests::IRBTreeDispatcher,
-            rb_tree_mock_contract::{RBTreeMockContract, IRBTreeMockContractDispatcher}
-        },
+        option_round::rb_tree::{rb_tree_mock_contract::{RBTreeMockContract}},
         utils::{
             lib::{
                 structs::{OptionRoundParams},
@@ -165,12 +162,12 @@ fn deploy_pitch_lake() -> IPitchLakeDispatcher {
     return IPitchLakeDispatcher { contract_address };
 }
 
-fn setup_rb_tree_test() -> IRBTreeMockContractDispatcher {
+fn setup_rb_tree_test() -> IRBTreeDispatcher {
     let (address, _) = deploy_syscall(
         RBTreeMockContract::TEST_CLASS_HASH.try_into().unwrap(), 0, array![].span(), false
     )
         .unwrap_syscall();
-    IRBTreeMockContractDispatcher { contract_address: address }
+    IRBTreeDispatcher { contract_address: address }
 }
 
 fn setup_facade() -> (VaultFacade, ERC20ABIDispatcher) {

--- a/src/tests/utils/helpers/setup.cairo
+++ b/src/tests/utils/helpers/setup.cairo
@@ -165,7 +165,7 @@ fn deploy_pitch_lake() -> IPitchLakeDispatcher {
     return IPitchLakeDispatcher { contract_address };
 }
 
-fn setup_rb_tree_test() -> IRBTreeMockContractDispatcher{
+fn setup_rb_tree_test() -> IRBTreeMockContractDispatcher {
     let (address, _) = deploy_syscall(
         RBTreeMockContract::TEST_CLASS_HASH.try_into().unwrap(), 0, array![].span(), false
     )


### PR DESCRIPTION
remove bulk of error messages on test files. they came from multiple interfaces sharing entry point naming