### PR TITLE
B9.0) RB tree accessibility fix & split RB tree implementations

### DIFF
--- a/src/contracts/components/red_black_tree.cairo
+++ b/src/contracts/components/red_black_tree.cairo
@@ -227,6 +227,22 @@ pub mod RBTreeComponent {
             node.color = color;
             self.tree.write(node_id, node);
         }
+
+        // Add a new node directly by accepting parent and value (bid)
+        fn _add_node(
+            ref self: ComponentState<TContractState>, bid: Bid, color: bool, parent: felt252
+        ) -> felt252 {
+            let new_node = Node { value: bid, left: 0, right: 0, parent: parent, color: color, };
+            let parent_node = self.tree.read(parent);
+            if bid <= parent_node.value {
+                self.update_left(parent, bid.id);
+            } else {
+                self.update_right(parent, bid.id);
+            }
+            self.update_parent(bid.id, parent);
+            self.tree.write(bid.id, new_node);
+            return bid.id;
+        }
     }
 
     #[generate_trait]
@@ -386,22 +402,6 @@ pub mod RBTreeComponent {
                 0
             };
             (true, current_black_height)
-        }
-
-        // Add a new node directly by accepting parent and value (bid)
-        fn _add_node(
-            ref self: ComponentState<TContractState>, bid: Bid, color: bool, parent: felt252
-        ) -> felt252 {
-            let new_node = Node { value: bid, left: 0, right: 0, parent: parent, color: color, };
-            let parent_node = self.tree.read(parent);
-            if bid <= parent_node.value {
-                self.update_left(parent, bid.id);
-            } else {
-                self.update_right(parent, bid.id);
-            }
-            self.update_parent(bid.id, parent);
-            self.tree.write(bid.id, new_node);
-            return bid.id;
         }
     }
 

--- a/src/contracts/components/red_black_tree.cairo
+++ b/src/contracts/components/red_black_tree.cairo
@@ -83,7 +83,7 @@ pub mod RBTreeComponent {
     }
 
     #[generate_trait]
-    pub impl RBTreeAuctionImpl<TContractState, +HasComponent<TContractState>> of RBTreeAuctionTrait<TContractState> {
+    pub impl RBTreeOptionImpl<TContractState, +HasComponent<TContractState>> of RBTreeOptionTrait<TContractState> {
         fn find_clearing_price(ref self: ComponentState<TContractState>) -> (u256, u256) {
             let total_options_available = self._get_total_options_available();
             let root: felt252 = self.root.read();

--- a/src/contracts/components/red_black_tree.cairo
+++ b/src/contracts/components/red_black_tree.cairo
@@ -64,7 +64,7 @@ pub mod RBTreeComponent {
             return node.value;
         }
 
-        fn update(ref self: ComponentState<TContractState>, bid_id: felt252, bid: Bid) {
+        fn _update(ref self: ComponentState<TContractState>, bid_id: felt252, bid: Bid) {
             let node: Node = self.tree.read(bid_id);
             if node.value.id == 0 {
                 return;
@@ -82,7 +82,7 @@ pub mod RBTreeComponent {
             self.delete_node(bid_id);
         }
 
-        fn find_clearing_price(ref self: ComponentState<TContractState>) -> (u256, u256) {
+        fn _find_clearing_price(ref self: ComponentState<TContractState>) -> (u256, u256) {
             let total_options_available = self._get_total_options_available();
             let root: felt252 = self.root.read();
             let root_node: Node = self.tree.read(root);
@@ -136,9 +136,9 @@ pub mod RBTreeComponent {
     }
 
     #[generate_trait]
-    pub impl InternalImpl<
+    pub impl RBTreeInternalImpl<
         TContractState, +HasComponent<TContractState>
-    > of InternalTrait<TContractState> {
+    > of RBTreeInternalTrait<TContractState> {
         fn traverse_postorder_clearing_price_from_node(
             ref self: ComponentState<TContractState>,
             current_id: felt252,

--- a/src/contracts/components/red_black_tree.cairo
+++ b/src/contracts/components/red_black_tree.cairo
@@ -41,9 +41,9 @@ pub mod RBTreeComponent {
     }
 
     #[generate_trait]
-    pub impl RBTreeInternalImpl<
+    pub impl RBTreeImpl<
         TContractState, +HasComponent<TContractState>
-    > of RBTreeInternalTrait<TContractState> {
+    > of RBTreeTrait<TContractState> {
         fn _insert(ref self: ComponentState<TContractState>, value: Bid) {
             let new_node_id = value.id;
 
@@ -136,9 +136,9 @@ pub mod RBTreeComponent {
     }
 
     #[generate_trait]
-    pub impl RBTreeInternalDetailedImpl<
+    pub impl InternalImpl<
         TContractState, +HasComponent<TContractState>
-    > of RBTreeInternalDetailedTrait<TContractState> {
+    > of InternalTrait<TContractState> {
         fn traverse_postorder_clearing_price_from_node(
             ref self: ComponentState<TContractState>,
             current_id: felt252,

--- a/src/contracts/components/red_black_tree.cairo
+++ b/src/contracts/components/red_black_tree.cairo
@@ -83,7 +83,7 @@ pub mod RBTreeComponent {
     }
 
     #[generate_trait]
-    pub impl RBTreeOptionImpl<TContractState, +HasComponent<TContractState>> of RBTreeOptionTrait<TContractState> {
+    pub impl RBTreeOptionRoundImpl<TContractState, +HasComponent<TContractState>> of RBTreeOptionRoundTrait<TContractState> {
         fn find_clearing_price(ref self: ComponentState<TContractState>) -> (u256, u256) {
             let total_options_available = self._get_total_options_available();
             let root: felt252 = self.root.read();

--- a/src/contracts/components/red_black_tree.cairo
+++ b/src/contracts/components/red_black_tree.cairo
@@ -260,21 +260,6 @@ pub mod RBTreeComponent {
             node.color = color;
             self.tree.write(node_id, node);
         }
-
-        fn _add_node(
-            ref self: ComponentState<TContractState>, bid: Bid, color: bool, parent: felt252
-        ) -> felt252 {
-            let new_node = Node { value: bid, left: 0, right: 0, parent: parent, color: color, };
-            let parent_node = self.tree.read(parent);
-            if bid <= parent_node.value {
-                self.update_left(parent, bid.id);
-            } else {
-                self.update_right(parent, bid.id);
-            }
-            self.update_parent(bid.id, parent);
-            self.tree.write(bid.id, new_node);
-            return bid.id;
-        }
     }
 
     #[generate_trait]
@@ -434,6 +419,22 @@ pub mod RBTreeComponent {
                 0
             };
             (true, current_black_height)
+        }
+
+        // Add a new node directly by accepting parent and value (bid)
+        fn _add_node(
+            ref self: ComponentState<TContractState>, bid: Bid, color: bool, parent: felt252
+        ) -> felt252 {
+            let new_node = Node { value: bid, left: 0, right: 0, parent: parent, color: color, };
+            let parent_node = self.tree.read(parent);
+            if bid <= parent_node.value {
+                self.update_left(parent, bid.id);
+            } else {
+                self.update_right(parent, bid.id);
+            }
+            self.update_parent(bid.id, parent);
+            self.tree.write(bid.id, new_node);
+            return bid.id;
         }
     }
 

--- a/src/contracts/components/red_black_tree.cairo
+++ b/src/contracts/components/red_black_tree.cairo
@@ -150,40 +150,7 @@ pub mod RBTreeComponent {
     }
 
     #[generate_trait]
-    pub impl RBTreeOperationsImpl<TContractState, +HasComponent<TContractState>> of RBTreeOperationsTrait<TContractState> {
-        fn insert_node_recursively(
-            ref self: ComponentState<TContractState>,
-            current_id: felt252,
-            new_node_id: felt252,
-            value: Bid
-        ) {
-            let mut current_node: Node = self.tree.read(current_id);
-            if value <= current_node.value {
-                if current_node.left == 0 {
-                    current_node.left = new_node_id;
-
-                    let new_node = self.create_leaf_node(@value, current_id);
-                    self.tree.write(new_node_id, new_node);
-                    self.tree.write(current_id, current_node);
-
-                    return;
-                }
-
-                self.insert_node_recursively(current_node.left, new_node_id, value);
-            } else {
-                if current_node.right == 0 {
-                    current_node.right = new_node_id;
-
-                    let new_node = self.create_leaf_node(@value, current_id);
-                    self.tree.write(new_node_id, new_node);
-                    self.tree.write(current_id, current_node);
-                    return;
-                }
-
-                self.insert_node_recursively(current_node.right, new_node_id, value);
-            }
-        }
-
+    impl RBTreeOperationsImpl<TContractState, +HasComponent<TContractState>> of RBTreeOperationsTrait<TContractState> {
         fn create_root_node(self: @ComponentState<TContractState>, value: @Bid) -> Node {
             Node { value: *value, left: 0, right: 0, parent: 0, color: BLACK, }
         }
@@ -643,6 +610,39 @@ pub mod RBTreeComponent {
     impl InsertBalance<
         TContractState, +HasComponent<TContractState>
     > of InsertBalanceTrait<TContractState> {
+        fn insert_node_recursively(
+            ref self: ComponentState<TContractState>,
+            current_id: felt252,
+            new_node_id: felt252,
+            value: Bid
+        ) {
+            let mut current_node: Node = self.tree.read(current_id);
+            if value <= current_node.value {
+                if current_node.left == 0 {
+                    current_node.left = new_node_id;
+
+                    let new_node = self.create_leaf_node(@value, current_id);
+                    self.tree.write(new_node_id, new_node);
+                    self.tree.write(current_id, current_node);
+
+                    return;
+                }
+
+                self.insert_node_recursively(current_node.left, new_node_id, value);
+            } else {
+                if current_node.right == 0 {
+                    current_node.right = new_node_id;
+
+                    let new_node = self.create_leaf_node(@value, current_id);
+                    self.tree.write(new_node_id, new_node);
+                    self.tree.write(current_id, current_node);
+                    return;
+                }
+
+                self.insert_node_recursively(current_node.right, new_node_id, value);
+            }
+        }
+
         fn balance_after_insertion(ref self: ComponentState<TContractState>, node_id: felt252) {
             let mut current = node_id;
             let mut current_node: Node = self.tree.read(current);

--- a/src/contracts/components/red_black_tree.cairo
+++ b/src/contracts/components/red_black_tree.cairo
@@ -406,9 +406,9 @@ pub mod RBTreeComponent {
     }
 
     #[generate_trait]
-    impl DeleteBalance<
+    impl RBTreeDeleteBalance<
         TContractState, +HasComponent<TContractState>
-    > of DeleteBalanceTrait<TContractState> {
+    > of RBTreeDeleteBalanceTrait<TContractState> {
         fn delete_node(ref self: ComponentState<TContractState>, delete_id: felt252) {
             let mut y = delete_id;
             let mut node_delete: Node = self.tree.read(delete_id);
@@ -607,9 +607,9 @@ pub mod RBTreeComponent {
     }
 
     #[generate_trait]
-    impl InsertBalance<
+    impl RBTreeInsertBalance<
         TContractState, +HasComponent<TContractState>
-    > of InsertBalanceTrait<TContractState> {
+    > of RBTreeInsertBalanceTrait<TContractState> {
         fn insert_node_recursively(
             ref self: ComponentState<TContractState>,
             current_id: felt252,

--- a/src/contracts/components/red_black_tree.cairo
+++ b/src/contracts/components/red_black_tree.cairo
@@ -82,7 +82,7 @@ pub mod RBTreeComponent {
             self.delete_node(bid_id);
         }
 
-        fn _find_clearing_price(ref self: ComponentState<TContractState>) -> (u256, u256) {
+        fn find_clearing_price(ref self: ComponentState<TContractState>) -> (u256, u256) {
             let total_options_available = self._get_total_options_available();
             let root: felt252 = self.root.read();
             let root_node: Node = self.tree.read(root);

--- a/src/contracts/components/red_black_tree.cairo
+++ b/src/contracts/components/red_black_tree.cairo
@@ -64,7 +64,7 @@ pub mod RBTreeComponent {
             return node.value;
         }
 
-        fn update(ref self: ComponentState<TContractState>, bid_id: felt252, bid: Bid) {
+        fn _update(ref self: ComponentState<TContractState>, bid_id: felt252, bid: Bid) {
             let node: Node = self.tree.read(bid_id);
             if node.value.id == 0 {
                 return;
@@ -75,13 +75,15 @@ pub mod RBTreeComponent {
 
         fn _delete(ref self: ComponentState<TContractState>, bid_id: felt252) {
             let node: Node = self.tree.read(bid_id);
-            // Check if bid exists
             if node.value.id == 0 {
                 return;
             }
             self.delete_node(bid_id);
         }
+    }
 
+    #[generate_trait]
+    pub impl RBTreeAuctionImpl<TContractState, +HasComponent<TContractState>> of RBTreeAuctionTrait<TContractState> {
         fn find_clearing_price(ref self: ComponentState<TContractState>) -> (u256, u256) {
             let total_options_available = self._get_total_options_available();
             let root: felt252 = self.root.read();
@@ -101,12 +103,6 @@ pub mod RBTreeComponent {
             (clearing_node.value.price, total_options_sold)
         }
 
-        fn _get_tree_structure(
-            self: @ComponentState<TContractState>
-        ) -> Array<Array<(u256, bool, u128)>> {
-            self.build_tree_structure_list()
-        }
-
         fn get_total_options_sold(self: @ComponentState<TContractState>) -> u256 {
             self.total_options_sold.read()
         }
@@ -115,30 +111,6 @@ pub mod RBTreeComponent {
             self.total_options_available.read()
         }
 
-        fn _is_tree_valid(self: @ComponentState<TContractState>) -> bool {
-            self.check_if_rb_tree_is_valid()
-        }
-
-        fn _add_node(
-            ref self: ComponentState<TContractState>, bid: Bid, color: bool, parent: felt252
-        ) -> felt252 {
-            let new_node = Node { value: bid, left: 0, right: 0, parent: parent, color: color, };
-            let parent_node = self.tree.read(parent);
-            if bid <= parent_node.value {
-                self.update_left(parent, bid.id);
-            } else {
-                self.update_right(parent, bid.id);
-            }
-            self.update_parent(bid.id, parent);
-            self.tree.write(bid.id, new_node);
-            return bid.id;
-        }
-    }
-
-    #[generate_trait]
-    pub impl RBTreeInternalImpl<
-        TContractState, +HasComponent<TContractState>
-    > of RBTreeInternalTrait<TContractState> {
         fn traverse_postorder_clearing_price_from_node(
             ref self: ComponentState<TContractState>,
             current_id: felt252,
@@ -175,24 +147,10 @@ pub mod RBTreeComponent {
                     current_node.left, remaining_options, clearing_price, current_id
                 )
         }
-        fn find_node(
-            ref self: ComponentState<TContractState>, current: felt252, value: Bid
-        ) -> felt252 {
-            if current == 0 {
-                return 0;
-            }
+    }
 
-            let node: Node = self.tree.read(current);
-
-            if value == node.value {
-                return current;
-            } else if value < node.value {
-                return self.find_node(node.left, value);
-            } else {
-                return self.find_node(node.right, value);
-            }
-        }
-
+    #[generate_trait]
+    pub impl RBTreeOperationsImpl<TContractState, +HasComponent<TContractState>> of RBTreeOperationsTrait<TContractState> {
         fn insert_node_recursively(
             ref self: ComponentState<TContractState>,
             current_id: felt252,
@@ -224,21 +182,6 @@ pub mod RBTreeComponent {
 
                 self.insert_node_recursively(current_node.right, new_node_id, value);
             }
-        }
-
-        fn remove_from_array<T, +Drop<T>, +PartialEq<T>>(
-            self: @ComponentState<TContractState>, element: T, mut array: Array<T>
-        ) -> Array<T> {
-            let mut new_array: Array<T> = array![];
-            loop {
-                match array.pop_front() {
-                    Option::Some(value) => { if (value != element) {
-                        new_array.append(value);
-                    } },
-                    Option::None => { break; }
-                }
-            };
-            new_array
         }
 
         fn create_root_node(self: @ComponentState<TContractState>, value: @Bid) -> Node {
@@ -316,6 +259,181 @@ pub mod RBTreeComponent {
             let mut node: Node = self.tree.read(node_id);
             node.color = color;
             self.tree.write(node_id, node);
+        }
+
+        fn _add_node(
+            ref self: ComponentState<TContractState>, bid: Bid, color: bool, parent: felt252
+        ) -> felt252 {
+            let new_node = Node { value: bid, left: 0, right: 0, parent: parent, color: color, };
+            let parent_node = self.tree.read(parent);
+            if bid <= parent_node.value {
+                self.update_left(parent, bid.id);
+            } else {
+                self.update_right(parent, bid.id);
+            }
+            self.update_parent(bid.id, parent);
+            self.tree.write(bid.id, new_node);
+            return bid.id;
+        }
+    }
+
+    #[generate_trait]
+    pub impl RBTreeTestingImpl<TContractState, +HasComponent<TContractState>> of RBTreeTestingTrait<TContractState> {
+        fn _get_tree_structure(
+            self: @ComponentState<TContractState>
+        ) -> Array<Array<(u256, bool, u128)>> {
+            self.build_tree_structure_list()
+        }
+
+        fn _is_tree_valid(self: @ComponentState<TContractState>) -> bool {
+            self.check_if_rb_tree_is_valid()
+        }
+
+        fn get_node_positions_by_level(
+            self: @ComponentState<TContractState>
+        ) -> Array<Array<(felt252, u128)>> {
+            let mut queue: Array<(felt252, u128)> = ArrayTrait::new();
+            let root_id = self.root.read();
+            let initial_level = 0;
+            let mut current_level = 0;
+            let mut filled_position_in_levels: Array<Array<(felt252, u128)>> = ArrayTrait::new();
+            let mut filled_position_in_level: Array<(felt252, u128)> = ArrayTrait::new();
+            let mut node_positions: Felt252Dict<u128> = Default::default();
+
+            self
+                .collect_position_and_levels_of_nodes(
+                    root_id, 0, initial_level, ref node_positions
+                );
+            queue.append((root_id, 0));
+
+            while !queue
+                .is_empty() {
+                    let (node_id, level) = queue.pop_front().unwrap();
+                    let node = self.tree.read(node_id);
+
+                    if level > current_level {
+                        current_level = level;
+                        filled_position_in_levels.append(filled_position_in_level);
+                        filled_position_in_level = ArrayTrait::new();
+                    }
+
+                    let position = node_positions.get(node_id);
+
+                    filled_position_in_level.append((node_id, position));
+
+                    if node.left != 0 {
+                        queue.append((node.left, current_level + 1));
+                    }
+
+                    if node.right != 0 {
+                        queue.append((node.right, current_level + 1));
+                    }
+                };
+            filled_position_in_levels.append(filled_position_in_level);
+            return filled_position_in_levels;
+        }
+
+        fn build_tree_structure_list(
+            self: @ComponentState<TContractState>
+        ) -> Array<Array<(u256, bool, u128)>> {
+            if (self.root.read() == 0) {
+                return ArrayTrait::new();
+            }
+            let filled_position_in_levels_original = self.get_node_positions_by_level();
+            let mut filled_position_in_levels: Array<Array<(u256, bool, u128)>> = ArrayTrait::new();
+            let mut filled_position_in_level: Array<(u256, bool, u128)> = ArrayTrait::new();
+            let mut i = 0;
+            while i < filled_position_in_levels_original
+                .len() {
+                    let level = filled_position_in_levels_original.at(i.try_into().unwrap());
+                    let mut j = 0;
+                    while j < level
+                        .len() {
+                            let (node_id, position) = level.at(j.try_into().unwrap());
+                            let node = self.tree.read(*node_id);
+                            filled_position_in_level
+                                .append((node.value.price, node.color, *position));
+                            j += 1;
+                        };
+                    filled_position_in_levels.append(filled_position_in_level);
+                    filled_position_in_level = ArrayTrait::new();
+                    i += 1;
+                };
+            return filled_position_in_levels;
+        }
+
+        fn collect_position_and_levels_of_nodes(
+            self: @ComponentState<TContractState>,
+            node_id: felt252,
+            position: u128,
+            level: u256,
+            ref node_positions: Felt252Dict<u128>
+        ) {
+            if node_id == 0 {
+                return;
+            }
+
+            let node = self.tree.read(node_id);
+
+            node_positions.insert(node_id, position);
+
+            self
+                .collect_position_and_levels_of_nodes(
+                    node.left, position * 2, level + 1, ref node_positions
+                );
+            self
+                .collect_position_and_levels_of_nodes(
+                    node.right, position * 2 + 1, level + 1, ref node_positions
+                );
+        }
+
+        fn check_if_rb_tree_is_valid(self: @ComponentState<TContractState>) -> bool {
+            let root = self.root.read();
+            if root == 0 {
+                return true; // An empty tree is a valid RB tree
+            }
+
+            // Check if root is black
+            if !self.is_black(root) {
+                return false;
+            }
+
+            // Check other properties
+            let (is_valid, _) = self.validate_node(root);
+            is_valid
+        }
+
+        fn validate_node(self: @ComponentState<TContractState>, node: felt252) -> (bool, u32) {
+            if node == 0 {
+                return (true, 1); // Null nodes are considered black
+            }
+
+            let node_data = self.tree.read(node);
+
+            let (left_valid, left_black_height) = self.validate_node(node_data.left);
+            let (right_valid, right_black_height) = self.validate_node(node_data.right);
+
+            if !left_valid || !right_valid {
+                return (false, 0);
+            }
+
+            // Check Red-Black properties
+            if self.is_red(node) {
+                if self.is_red(node_data.left) || self.is_red(node_data.right) {
+                    return (false, 0); // Red node cannot have red children
+                }
+            }
+
+            if left_black_height != right_black_height {
+                return (false, 0); // Black height must be the same for both subtrees
+            }
+
+            let current_black_height = left_black_height + if self.is_black(node) {
+                1
+            } else {
+                0
+            };
+            (true, current_black_height)
         }
     }
 
@@ -501,6 +619,7 @@ pub mod RBTreeComponent {
             };
             current
         }
+
 
         fn get_default_node(ref self: ComponentState<TContractState>) -> Node {
             Node { value: self.get_default_bid(), left: 0, right: 0, parent: 0, color: BLACK, }
@@ -703,163 +822,6 @@ pub mod RBTreeComponent {
 
             // Return the new root of the subtree
             y
-        }
-    }
-
-    #[generate_trait]
-    impl RBTreeStructure<
-        TContractState, +HasComponent<TContractState>
-    > of RBTreeGetStructureTrait<TContractState> {
-        fn get_node_positions_by_level(
-            self: @ComponentState<TContractState>
-        ) -> Array<Array<(felt252, u128)>> {
-            let mut queue: Array<(felt252, u128)> = ArrayTrait::new();
-            let root_id = self.root.read();
-            let initial_level = 0;
-            let mut current_level = 0;
-            let mut filled_position_in_levels: Array<Array<(felt252, u128)>> = ArrayTrait::new();
-            let mut filled_position_in_level: Array<(felt252, u128)> = ArrayTrait::new();
-            let mut node_positions: Felt252Dict<u128> = Default::default();
-
-            self
-                .collect_position_and_levels_of_nodes(
-                    root_id, 0, initial_level, ref node_positions
-                );
-            queue.append((root_id, 0));
-
-            while !queue
-                .is_empty() {
-                    let (node_id, level) = queue.pop_front().unwrap();
-                    let node = self.tree.read(node_id);
-
-                    if level > current_level {
-                        current_level = level;
-                        filled_position_in_levels.append(filled_position_in_level);
-                        filled_position_in_level = ArrayTrait::new();
-                    }
-
-                    let position = node_positions.get(node_id);
-
-                    filled_position_in_level.append((node_id, position));
-
-                    if node.left != 0 {
-                        queue.append((node.left, current_level + 1));
-                    }
-
-                    if node.right != 0 {
-                        queue.append((node.right, current_level + 1));
-                    }
-                };
-            filled_position_in_levels.append(filled_position_in_level);
-            return filled_position_in_levels;
-        }
-
-        fn build_tree_structure_list(
-            self: @ComponentState<TContractState>
-        ) -> Array<Array<(u256, bool, u128)>> {
-            if (self.root.read() == 0) {
-                return ArrayTrait::new();
-            }
-            let filled_position_in_levels_original = self.get_node_positions_by_level();
-            let mut filled_position_in_levels: Array<Array<(u256, bool, u128)>> = ArrayTrait::new();
-            let mut filled_position_in_level: Array<(u256, bool, u128)> = ArrayTrait::new();
-            let mut i = 0;
-            while i < filled_position_in_levels_original
-                .len() {
-                    let level = filled_position_in_levels_original.at(i.try_into().unwrap());
-                    let mut j = 0;
-                    while j < level
-                        .len() {
-                            let (node_id, position) = level.at(j.try_into().unwrap());
-                            let node = self.tree.read(*node_id);
-                            filled_position_in_level
-                                .append((node.value.price, node.color, *position));
-                            j += 1;
-                        };
-                    filled_position_in_levels.append(filled_position_in_level);
-                    filled_position_in_level = ArrayTrait::new();
-                    i += 1;
-                };
-            return filled_position_in_levels;
-        }
-
-        fn collect_position_and_levels_of_nodes(
-            self: @ComponentState<TContractState>,
-            node_id: felt252,
-            position: u128,
-            level: u256,
-            ref node_positions: Felt252Dict<u128>
-        ) {
-            if node_id == 0 {
-                return;
-            }
-
-            let node = self.tree.read(node_id);
-
-            node_positions.insert(node_id, position);
-
-            self
-                .collect_position_and_levels_of_nodes(
-                    node.left, position * 2, level + 1, ref node_positions
-                );
-            self
-                .collect_position_and_levels_of_nodes(
-                    node.right, position * 2 + 1, level + 1, ref node_positions
-                );
-        }
-    }
-
-    #[generate_trait]
-    impl RBTreeValidation<
-        TContractState, +HasComponent<TContractState>
-    > of RBTreeValidationTrait<TContractState> {
-        fn check_if_rb_tree_is_valid(self: @ComponentState<TContractState>) -> bool {
-            let root = self.root.read();
-            if root == 0 {
-                return true; // An empty tree is a valid RB tree
-            }
-
-            // Check if root is black
-            if !self.is_black(root) {
-                return false;
-            }
-
-            // Check other properties
-            let (is_valid, _) = self.validate_node(root);
-            is_valid
-        }
-
-        fn validate_node(self: @ComponentState<TContractState>, node: felt252) -> (bool, u32) {
-            if node == 0 {
-                return (true, 1); // Null nodes are considered black
-            }
-
-            let node_data = self.tree.read(node);
-
-            let (left_valid, left_black_height) = self.validate_node(node_data.left);
-            let (right_valid, right_black_height) = self.validate_node(node_data.right);
-
-            if !left_valid || !right_valid {
-                return (false, 0);
-            }
-
-            // Check Red-Black properties
-            if self.is_red(node) {
-                if self.is_red(node_data.left) || self.is_red(node_data.right) {
-                    return (false, 0); // Red node cannot have red children
-                }
-            }
-
-            if left_black_height != right_black_height {
-                return (false, 0); // Black height must be the same for both subtrees
-            }
-
-            let current_black_height = left_black_height + if self.is_black(node) {
-                1
-            } else {
-                0
-            };
-            (true, current_black_height)
         }
     }
 }

--- a/src/contracts/components/red_black_tree.cairo
+++ b/src/contracts/components/red_black_tree.cairo
@@ -64,7 +64,7 @@ pub mod RBTreeComponent {
             return node.value;
         }
 
-        fn _update(ref self: ComponentState<TContractState>, bid_id: felt252, bid: Bid) {
+        fn update(ref self: ComponentState<TContractState>, bid_id: felt252, bid: Bid) {
             let node: Node = self.tree.read(bid_id);
             if node.value.id == 0 {
                 return;

--- a/src/contracts/option_round/contract.cairo
+++ b/src/contracts/option_round/contract.cairo
@@ -861,7 +861,7 @@ mod OptionRound {
                 let options_sold = self.bids_tree.clearing_bid_amount_sold.read();
                 if (!partial_bid.is_refunded) {
                     partial_bid.is_refunded = true;
-                    self.bids_tree._update(partial_bid_id, partial_bid);
+                    self.bids_tree.update(partial_bid_id, partial_bid);
                     refundable_balance += (partial_bid.amount - options_sold) * partial_bid.price;
                 }
             }
@@ -872,7 +872,7 @@ mod OptionRound {
                         if (!bid.is_refunded) {
                             let mut refundable_bid: Bid = self.bids_tree._find(bid.id);
                             refundable_bid.is_refunded = true;
-                            self.bids_tree._update(refundable_bid.id, refundable_bid);
+                            self.bids_tree.update(refundable_bid.id, refundable_bid);
                             refundable_balance += bid.amount * bid.price;
                         }
                     },
@@ -887,7 +887,7 @@ mod OptionRound {
                         if (!bid.is_refunded) {
                             let mut refundable_bid: Bid = self.bids_tree._find(bid.id);
                             refundable_bid.is_refunded = true;
-                            self.bids_tree._update(refundable_bid.id, refundable_bid);
+                            self.bids_tree.update(refundable_bid.id, refundable_bid);
                             refundable_balance += bid.amount * (bid.price - clearing_price)
                         }
                     },
@@ -936,7 +936,7 @@ mod OptionRound {
                     let options_sold = self.bids_tree.clearing_bid_amount_sold.read();
                     options_to_exercise += options_sold;
                     partial_bid.is_tokenized = true;
-                    self.bids_tree._update(partial_bid_id, partial_bid);
+                    self.bids_tree.update(partial_bid_id, partial_bid);
                 }
             }
             loop {
@@ -945,7 +945,7 @@ mod OptionRound {
                         if (!bid.is_tokenized) {
                             let mut bid: Bid = self.bids_tree._find(bid.id);
                             bid.is_tokenized = true;
-                            self.bids_tree._update(bid.id, bid);
+                            self.bids_tree.update(bid.id, bid);
                             options_to_exercise += bid.amount;
                         }
                     },
@@ -1004,7 +1004,7 @@ mod OptionRound {
                     let options_sold = self.bids_tree.clearing_bid_amount_sold.read();
                     options_to_mint += options_sold;
                     partial_bid.is_tokenized = true;
-                    self.bids_tree._update(partial_bid_id, partial_bid);
+                    self.bids_tree.update(partial_bid_id, partial_bid);
                 }
             }
             loop {
@@ -1013,7 +1013,7 @@ mod OptionRound {
                         if (!bid.is_tokenized) {
                             let mut bid: Bid = self.bids_tree._find(bid.id);
                             bid.is_tokenized = true;
-                            self.bids_tree._update(bid.id, bid);
+                            self.bids_tree.update(bid.id, bid);
                             options_to_mint += bid.amount;
                         }
                     },

--- a/src/contracts/option_round/contract.cairo
+++ b/src/contracts/option_round/contract.cairo
@@ -861,7 +861,7 @@ mod OptionRound {
                 let options_sold = self.bids_tree.clearing_bid_amount_sold.read();
                 if (!partial_bid.is_refunded) {
                     partial_bid.is_refunded = true;
-                    self.bids_tree.update(partial_bid_id, partial_bid);
+                    self.bids_tree._update(partial_bid_id, partial_bid);
                     refundable_balance += (partial_bid.amount - options_sold) * partial_bid.price;
                 }
             }
@@ -872,7 +872,7 @@ mod OptionRound {
                         if (!bid.is_refunded) {
                             let mut refundable_bid: Bid = self.bids_tree._find(bid.id);
                             refundable_bid.is_refunded = true;
-                            self.bids_tree.update(refundable_bid.id, refundable_bid);
+                            self.bids_tree._update(refundable_bid.id, refundable_bid);
                             refundable_balance += bid.amount * bid.price;
                         }
                     },
@@ -887,7 +887,7 @@ mod OptionRound {
                         if (!bid.is_refunded) {
                             let mut refundable_bid: Bid = self.bids_tree._find(bid.id);
                             refundable_bid.is_refunded = true;
-                            self.bids_tree.update(refundable_bid.id, refundable_bid);
+                            self.bids_tree._update(refundable_bid.id, refundable_bid);
                             refundable_balance += bid.amount * (bid.price - clearing_price)
                         }
                     },
@@ -936,7 +936,7 @@ mod OptionRound {
                     let options_sold = self.bids_tree.clearing_bid_amount_sold.read();
                     options_to_exercise += options_sold;
                     partial_bid.is_tokenized = true;
-                    self.bids_tree.update(partial_bid_id, partial_bid);
+                    self.bids_tree._update(partial_bid_id, partial_bid);
                 }
             }
             loop {
@@ -945,7 +945,7 @@ mod OptionRound {
                         if (!bid.is_tokenized) {
                             let mut bid: Bid = self.bids_tree._find(bid.id);
                             bid.is_tokenized = true;
-                            self.bids_tree.update(bid.id, bid);
+                            self.bids_tree._update(bid.id, bid);
                             options_to_exercise += bid.amount;
                         }
                     },
@@ -1004,7 +1004,7 @@ mod OptionRound {
                     let options_sold = self.bids_tree.clearing_bid_amount_sold.read();
                     options_to_mint += options_sold;
                     partial_bid.is_tokenized = true;
-                    self.bids_tree.update(partial_bid_id, partial_bid);
+                    self.bids_tree._update(partial_bid_id, partial_bid);
                 }
             }
             loop {
@@ -1013,7 +1013,7 @@ mod OptionRound {
                         if (!bid.is_tokenized) {
                             let mut bid: Bid = self.bids_tree._find(bid.id);
                             bid.is_tokenized = true;
-                            self.bids_tree.update(bid.id, bid);
+                            self.bids_tree._update(bid.id, bid);
                             options_to_mint += bid.amount;
                         }
                     },

--- a/src/contracts/option_round/contract.cairo
+++ b/src/contracts/option_round/contract.cairo
@@ -1049,7 +1049,7 @@ mod OptionRound {
 
         // Calculate the clearing price and total options sold from the auction
         fn update_clearing_price(ref self: ContractState) -> (u256, u256) {
-            self.bids_tree._find_clearing_price()
+            self.bids_tree.find_clearing_price()
         }
 
         //Get bid tree nonce

--- a/src/contracts/option_round/contract.cairo
+++ b/src/contracts/option_round/contract.cairo
@@ -37,7 +37,7 @@ mod OptionRound {
     component!(path: RBTreeComponent, storage: bids_tree, event: BidTreeEvent);
 
     impl RBTreeImpl = RBTreeComponent::RBTreeImpl<ContractState>;
-    impl RBTreeInternalImpl = RBTreeComponent::RBTreeInternalImpl<ContractState>;
+    impl RBTreeOptionImpl = RBTreeComponent::RBTreeOptionTrait<ContractState>;
 
     // *************************************************************************
     //                              STORAGE

--- a/src/contracts/option_round/contract.cairo
+++ b/src/contracts/option_round/contract.cairo
@@ -37,7 +37,7 @@ mod OptionRound {
     component!(path: RBTreeComponent, storage: bids_tree, event: BidTreeEvent);
 
     impl RBTreeImpl = RBTreeComponent::RBTreeImpl<ContractState>;
-    impl RBTreeInternalImpl = RBTreeComponent::InternalImpl<ContractState>;
+    impl RBTreeInternalImpl = RBTreeComponent::RBTreeInternalImpl<ContractState>;
 
     // *************************************************************************
     //                              STORAGE
@@ -861,7 +861,7 @@ mod OptionRound {
                 let options_sold = self.bids_tree.clearing_bid_amount_sold.read();
                 if (!partial_bid.is_refunded) {
                     partial_bid.is_refunded = true;
-                    self.bids_tree.update(partial_bid_id, partial_bid);
+                    self.bids_tree._update(partial_bid_id, partial_bid);
                     refundable_balance += (partial_bid.amount - options_sold) * partial_bid.price;
                 }
             }
@@ -872,7 +872,7 @@ mod OptionRound {
                         if (!bid.is_refunded) {
                             let mut refundable_bid: Bid = self.bids_tree._find(bid.id);
                             refundable_bid.is_refunded = true;
-                            self.bids_tree.update(refundable_bid.id, refundable_bid);
+                            self.bids_tree._update(refundable_bid.id, refundable_bid);
                             refundable_balance += bid.amount * bid.price;
                         }
                     },
@@ -887,7 +887,7 @@ mod OptionRound {
                         if (!bid.is_refunded) {
                             let mut refundable_bid: Bid = self.bids_tree._find(bid.id);
                             refundable_bid.is_refunded = true;
-                            self.bids_tree.update(refundable_bid.id, refundable_bid);
+                            self.bids_tree._update(refundable_bid.id, refundable_bid);
                             refundable_balance += bid.amount * (bid.price - clearing_price)
                         }
                     },
@@ -936,7 +936,7 @@ mod OptionRound {
                     let options_sold = self.bids_tree.clearing_bid_amount_sold.read();
                     options_to_exercise += options_sold;
                     partial_bid.is_tokenized = true;
-                    self.bids_tree.update(partial_bid_id, partial_bid);
+                    self.bids_tree._update(partial_bid_id, partial_bid);
                 }
             }
             loop {
@@ -945,7 +945,7 @@ mod OptionRound {
                         if (!bid.is_tokenized) {
                             let mut bid: Bid = self.bids_tree._find(bid.id);
                             bid.is_tokenized = true;
-                            self.bids_tree.update(bid.id, bid);
+                            self.bids_tree._update(bid.id, bid);
                             options_to_exercise += bid.amount;
                         }
                     },
@@ -1004,7 +1004,7 @@ mod OptionRound {
                     let options_sold = self.bids_tree.clearing_bid_amount_sold.read();
                     options_to_mint += options_sold;
                     partial_bid.is_tokenized = true;
-                    self.bids_tree.update(partial_bid_id, partial_bid);
+                    self.bids_tree._update(partial_bid_id, partial_bid);
                 }
             }
             loop {
@@ -1013,7 +1013,7 @@ mod OptionRound {
                         if (!bid.is_tokenized) {
                             let mut bid: Bid = self.bids_tree._find(bid.id);
                             bid.is_tokenized = true;
-                            self.bids_tree.update(bid.id, bid);
+                            self.bids_tree._update(bid.id, bid);
                             options_to_mint += bid.amount;
                         }
                     },
@@ -1049,7 +1049,7 @@ mod OptionRound {
 
         // Calculate the clearing price and total options sold from the auction
         fn update_clearing_price(ref self: ContractState) -> (u256, u256) {
-            self.bids_tree.find_clearing_price()
+            self.bids_tree._find_clearing_price()
         }
 
         //Get bid tree nonce

--- a/src/contracts/option_round/contract.cairo
+++ b/src/contracts/option_round/contract.cairo
@@ -37,7 +37,7 @@ mod OptionRound {
     component!(path: RBTreeComponent, storage: bids_tree, event: BidTreeEvent);
 
     impl RBTreeImpl = RBTreeComponent::RBTreeImpl<ContractState>;
-    impl RBTreeOptionImpl = RBTreeComponent::RBTreeOptionTrait<ContractState>;
+    impl RBTreeOptionRoundImpl = RBTreeComponent::RBTreeOptionRoundImpl<ContractState>;
 
     // *************************************************************************
     //                              STORAGE

--- a/src/tests/option_round/rb_tree/rb_tree_mock_contract.cairo
+++ b/src/tests/option_round/rb_tree/rb_tree_mock_contract.cairo
@@ -13,6 +13,7 @@ pub trait IRBTreeMockContract<TContractState> {
 #[starknet::contract]
 mod RBTreeMockContract {
     use pitch_lake_starknet::contracts::components::red_black_tree::RBTreeComponent;
+    use pitch_lake_starknet::{contracts::{option_round::{types::{Bid}}}};
 
     component!(path: RBTreeComponent, storage: rb_tree, event: RBTreeEvent);
 

--- a/src/tests/option_round/rb_tree/rb_tree_mock_contract.cairo
+++ b/src/tests/option_round/rb_tree/rb_tree_mock_contract.cairo
@@ -1,7 +1,7 @@
 use pitch_lake_starknet::{contracts::{option_round::{types::{Bid}}}};
 
 #[starknet::interface]
-pub trait IRBTreeMockContract<TContractState> {
+trait IRBTreeMockContract<TContractState> {
     fn insert(ref self: TContractState, value: Bid);
     fn find(self: @TContractState, bid_id: felt252) -> Bid;
     fn get_tree_structure(self: @TContractState) -> Array<Array<(u256, bool, u128)>>;
@@ -31,28 +31,31 @@ mod RBTreeMockContract {
         RBTreeEvent: RBTreeComponent::Event
     }
 
-    fn insert(ref self:ContractState, value: Bid) {
-        self.rb_tree._insert(value);
-    }
-
-    fn find(self: @ContractState, bid_id: felt252) -> Bid {
-        self.rb_tree._find(bid_id)
-    }
-
-    fn get_tree_structure(self: @ContractState) -> Array<Array<(u256, bool, u128)>> {
-        self.rb_tree._get_tree_structure()
-    }
-
-    fn is_tree_valid(self: @ContractState) -> bool {
-        self.rb_tree._is_tree_valid()
-    }
-
-    fn delete(ref self: ContractState, bid_id: felt252) {
-        self.rb_tree._delete(bid_id);
-    }
-
-    fn add_node(ref self: ContractState, value: Bid, color: bool, parent: felt252) -> felt252 {
-        self.rb_tree._add_node(value, color, parent)
+    #[abi(embed_v0)]
+    impl RBTreeMockContractImpl of super::IRBTreeMockContract<ContractState> {
+        fn insert(ref self:ContractState, value: Bid) {
+            self.rb_tree._insert(value);
+        }
+    
+        fn find(self: @ContractState, bid_id: felt252) -> Bid {
+            self.rb_tree._find(bid_id)
+        }
+    
+        fn get_tree_structure(self: @ContractState) -> Array<Array<(u256, bool, u128)>> {
+            self.rb_tree._get_tree_structure()
+        }
+    
+        fn is_tree_valid(self: @ContractState) -> bool {
+            self.rb_tree._is_tree_valid()
+        }
+    
+        fn delete(ref self: ContractState, bid_id: felt252) {
+            self.rb_tree._delete(bid_id);
+        }
+    
+        fn add_node(ref self: ContractState, value: Bid, color: bool, parent: felt252) -> felt252 {
+            self.rb_tree._add_node(value, color, parent)
+        }
     }
 }
 

--- a/src/tests/option_round/rb_tree/rb_tree_mock_contract.cairo
+++ b/src/tests/option_round/rb_tree/rb_tree_mock_contract.cairo
@@ -13,7 +13,7 @@ trait IRBTreeMockContract<TContractState> {
 #[starknet::contract]
 mod RBTreeMockContract {
     use pitch_lake_starknet::contracts::components::red_black_tree::RBTreeComponent;
-    use pitch_lake_starknet::{contracts::{option_round::{types::{Bid}}}};
+    use pitch_lake_starknet::{contracts::{option_round::{types::Bid}}};
 
     component!(path: RBTreeComponent, storage: rb_tree, event: RBTreeEvent);
 

--- a/src/tests/option_round/rb_tree/rb_tree_mock_contract.cairo
+++ b/src/tests/option_round/rb_tree/rb_tree_mock_contract.cairo
@@ -19,6 +19,8 @@ mod RBTreeMockContract {
 
     impl RBTreeImpl = RBTreeComponent::RBTreeImpl<ContractState>;
     impl RBTreeTestingImpl = RBTreeComponent::RBTreeTestingImpl<ContractState>;
+    impl RBTreeOperationsImpl = RBTreeComponent::RBTreeOperationsImpl<ContractState>;
+    
 
     #[storage]
     struct Storage {
@@ -55,7 +57,8 @@ mod RBTreeMockContract {
         fn is_tree_valid(self: @ContractState) -> bool {
             self.rb_tree._is_tree_valid()
         }
-    
+        
+        // Internal function for testing
         fn add_node(ref self: ContractState, value: Bid, color: bool, parent: felt252) -> felt252 {
             self.rb_tree._add_node(value, color, parent)
         }

--- a/src/tests/option_round/rb_tree/rb_tree_mock_contract.cairo
+++ b/src/tests/option_round/rb_tree/rb_tree_mock_contract.cairo
@@ -17,7 +17,8 @@ mod RBTreeMockContract {
 
     component!(path: RBTreeComponent, storage: rb_tree, event: RBTreeEvent);
 
-    impl RBTreeInternalImpl = RBTreeComponent::RBTreeImpl<ContractState>;
+    impl RBTreeImpl = RBTreeComponent::RBTreeImpl<ContractState>;
+    impl RBTreeTestingImpl = RBTreeComponent::RBTreeTestingImpl<ContractState>;
 
     #[storage]
     struct Storage {
@@ -33,6 +34,7 @@ mod RBTreeMockContract {
 
     #[abi(embed_v0)]
     impl RBTreeMockContractImpl of super::IRBTreeMockContract<ContractState> {
+        // Tree main functions
         fn insert(ref self:ContractState, value: Bid) {
             self.rb_tree._insert(value);
         }
@@ -40,17 +42,18 @@ mod RBTreeMockContract {
         fn find(self: @ContractState, bid_id: felt252) -> Bid {
             self.rb_tree._find(bid_id)
         }
-    
+            
+        fn delete(ref self: ContractState, bid_id: felt252) {
+            self.rb_tree._delete(bid_id);
+        }
+        
+        // Tree testing functions
         fn get_tree_structure(self: @ContractState) -> Array<Array<(u256, bool, u128)>> {
             self.rb_tree._get_tree_structure()
         }
     
         fn is_tree_valid(self: @ContractState) -> bool {
             self.rb_tree._is_tree_valid()
-        }
-    
-        fn delete(ref self: ContractState, bid_id: felt252) {
-            self.rb_tree._delete(bid_id);
         }
     
         fn add_node(ref self: ContractState, value: Bid, color: bool, parent: felt252) -> felt252 {

--- a/src/tests/option_round/rb_tree/rb_tree_mock_contract.cairo
+++ b/src/tests/option_round/rb_tree/rb_tree_mock_contract.cairo
@@ -1,8 +1,22 @@
+use pitch_lake_starknet::{contracts::{option_round::{types::{Bid}}}};
+
+#[starknet::interface]
+pub trait IRBTreeMockContract<TContractState> {
+    fn insert(ref self: TContractState, value: Bid);
+    fn find(self: @TContractState, bid_id: felt252) -> Bid;
+    fn get_tree_structure(self: @TContractState) -> Array<Array<(u256, bool, u128)>>;
+    fn is_tree_valid(self: @TContractState) -> bool;
+    fn delete(ref self: TContractState, bid_id: felt252);
+    fn add_node(ref self: TContractState, value: Bid, color: bool, parent: felt252) -> felt252;
+}
+
 #[starknet::contract]
 mod RBTreeMockContract {
     use pitch_lake_starknet::contracts::components::red_black_tree::RBTreeComponent;
 
     component!(path: RBTreeComponent, storage: rb_tree, event: RBTreeEvent);
+
+    impl RBTreeInternalImpl = RBTreeComponent::RBTreeInternalImpl<ContractState>;
 
     #[storage]
     struct Storage {
@@ -16,7 +30,28 @@ mod RBTreeMockContract {
         RBTreeEvent: RBTreeComponent::Event
     }
 
-    #[abi(embed_v0)]
-    impl RBTreeImpl = RBTreeComponent::RBTree<ContractState>;
+    fn insert(ref self:ContractState, value: Bid) {
+        self.rb_tree._insert(value);
+    }
+
+    fn find(self: @ContractState, bid_id: felt252) -> Bid {
+        self.rb_tree._find(bid_id)
+    }
+
+    fn get_tree_structure(self: @ContractState) -> Array<Array<(u256, bool, u128)>> {
+        self.rb_tree._get_tree_structure()
+    }
+
+    fn is_tree_valid(self: @ContractState) -> bool {
+        self.rb_tree._is_tree_valid()
+    }
+
+    fn delete(ref self: ContractState, bid_id: felt252) {
+        self.rb_tree._delete(bid_id);
+    }
+
+    fn add_node(ref self: ContractState, value: Bid, color: bool, parent: felt252) -> felt252 {
+        self.rb_tree._add_node(value, color, parent)
+    }
 }
 

--- a/src/tests/option_round/rb_tree/rb_tree_mock_contract.cairo
+++ b/src/tests/option_round/rb_tree/rb_tree_mock_contract.cairo
@@ -17,7 +17,7 @@ mod RBTreeMockContract {
 
     component!(path: RBTreeComponent, storage: rb_tree, event: RBTreeEvent);
 
-    impl RBTreeInternalImpl = RBTreeComponent::RBTreeInternalImpl<ContractState>;
+    impl RBTreeInternalImpl = RBTreeComponent::RBTreeImpl<ContractState>;
 
     #[storage]
     struct Storage {

--- a/src/tests/option_round/rb_tree/rb_tree_stress_tests.cairo
+++ b/src/tests/option_round/rb_tree/rb_tree_stress_tests.cairo
@@ -1,13 +1,17 @@
 use pitch_lake_starknet::{
     tests::{
         utils::helpers::setup::setup_rb_tree_test,
-        option_round::rb_tree::rb_tree_tests::{
-            insert, mock_address, MOCK_ADDRESS, delete, create_bid
-        },
+        option_round::rb_tree::{
+            rb_tree_tests::{
+                insert, mock_address, MOCK_ADDRESS, delete, create_bid
+            },
+            rb_tree_mock_contract::{
+                IRBTreeMockContractDispatcher, IRBTreeMockContractDispatcherTrait
+            }
+        }
     },
     contracts::{
         option_round::types::Bid,
-        components::red_black_tree::{IRBTreeDispatcher, IRBTreeDispatcherTrait}
     },
 };
 use core::pedersen::pedersen;

--- a/src/tests/option_round/rb_tree/rb_tree_tests.cairo
+++ b/src/tests/option_round/rb_tree/rb_tree_tests.cairo
@@ -1,9 +1,17 @@
 use core::traits::TryInto;
 use pitch_lake_starknet::{
     contracts::{
-        option_round::{types::{Bid}},
-        components::{red_black_tree::{IRBTreeDispatcher, IRBTreeDispatcherTrait}},
+        option_round::{
+            types::{Bid},
+        },
     },
+    tests::{
+        option_round::{
+            rb_tree::rb_tree_mock_contract::{
+                IRBTreeMockContractDispatcher, IRBTreeMockContractDispatcherTrait
+            }
+        }
+    }
 };
 use starknet::{contract_address_const, ContractAddress};
 use core::pedersen::pedersen;
@@ -1238,7 +1246,7 @@ fn create_bid(price: u256, nonce: u64) -> Bid {
     }
 }
 
-fn insert(rb_tree: IRBTreeDispatcher, price: u256, nonce: u64) -> felt252 {
+fn insert(rb_tree: IRBTreeMockContractDispatcher, price: u256, nonce: u64) -> felt252 {
     let bidder = mock_address(MOCK_ADDRESS);
     let id = poseidon::poseidon_hash_span(array![bidder.into(), nonce.try_into().unwrap()].span());
     rb_tree
@@ -1256,13 +1264,13 @@ fn insert(rb_tree: IRBTreeDispatcher, price: u256, nonce: u64) -> felt252 {
     return id;
 }
 
-fn is_tree_valid(rb_tree: IRBTreeDispatcher) -> bool {
+fn is_tree_valid(rb_tree: IRBTreeMockContractDispatcher) -> bool {
     let is_tree_valid = rb_tree.is_tree_valid();
     //println!("Is tree valid: {:?}", is_tree_valid);
     is_tree_valid
 }
 
-fn delete(rb_tree: IRBTreeDispatcher, bid_id: felt252) {
+fn delete(rb_tree: IRBTreeMockContractDispatcher, bid_id: felt252) {
     rb_tree.delete(bid_id);
 }
 

--- a/src/tests/option_round/rb_tree/rb_tree_tests.cairo
+++ b/src/tests/option_round/rb_tree/rb_tree_tests.cairo
@@ -22,7 +22,7 @@ const RED: bool = true;
 const MOCK_ADDRESS: felt252 = 123456;
 
 fn mock_address(value: felt252) -> ContractAddress {
-    contract_address_const::<'liquidity_provider_1'>()
+    contract_address_const::<'test_contract_address'>()
 }
 
 // Tests for insertion

--- a/src/tests/utils/helpers/setup.cairo
+++ b/src/tests/utils/helpers/setup.cairo
@@ -12,7 +12,7 @@ use openzeppelin::{
 };
 use pitch_lake_starknet::{
     contracts::{
-        components::{eth::Eth, red_black_tree::{IRBTreeDispatcher, IRBTreeDispatcherTrait}},
+        components::{eth::Eth},
         pitch_lake::{
             IPitchLakeDispatcher, IPitchLakeSafeDispatcher, IPitchLakeDispatcherTrait, PitchLake,
             IPitchLakeSafeDispatcherTrait
@@ -35,7 +35,7 @@ use pitch_lake_starknet::{
         },
     },
     tests::{
-        option_round::rb_tree::{rb_tree_mock_contract::{RBTreeMockContract}},
+        option_round::rb_tree::{rb_tree_mock_contract::{RBTreeMockContract, IRBTreeMockContractDispatcher, IRBTreeMockContractDispatcherTrait }},
         utils::{
             lib::{
                 structs::{OptionRoundParams},
@@ -162,12 +162,12 @@ fn deploy_pitch_lake() -> IPitchLakeDispatcher {
     return IPitchLakeDispatcher { contract_address };
 }
 
-fn setup_rb_tree_test() -> IRBTreeDispatcher {
+fn setup_rb_tree_test() -> IRBTreeMockContractDispatcher {
     let (address, _) = deploy_syscall(
         RBTreeMockContract::TEST_CLASS_HASH.try_into().unwrap(), 0, array![].span(), false
     )
         .unwrap_syscall();
-    IRBTreeDispatcher { contract_address: address }
+    IRBTreeMockContractDispatcher { contract_address: address }
 }
 
 fn setup_facade() -> (VaultFacade, ERC20ABIDispatcher) {


### PR DESCRIPTION
* Changed RB tree trait from embeddable to internal
* Refactored RB tree functions into distinct traits for distinct functionalities
* Split the tree in the following way

1. RBTreeTrait:
    _insert
    _find
    _update
    _delete

2. RBTreeOptionRoundTrait:
    find_clearing_price
    get_total_options_sold
    _get_total_options_available
    traverse_postorder_clearing_price_from_node

3. RBTreeOperationsTrait:
    create_root_node
    create_leaf_node
    is_left_child
    update_left
    update_right
    update_parent
    get_parent
    is_black
    is_red
    ensure_root_is_black
    set_color
  _add_node // Adds a node directly to the tree by accepting parent and value

4. RBTreeTestingTrait:
    _get_tree_structure
    _is_tree_valid
    get_node_positions_by_level
    build_tree_structure_list
    collect_position_and_levels_of_nodes
    check_if_rb_tree_is_valid
    validate_node

5. RBTreeDeleteBalanceTrait:
    delete_node
    delete_fixup
    transplant
    minimum
    get_default_node // To replace the deleted node with null node
    get_default_bid

6. RBTreeInsertBalanceTrait:
    insert_node_recursively
    balance_after_insertion
    balance_left_case
    balance_right_case
    handle_red_uncle
    handle_black_uncle_left
    handle_black_uncle_right

7. RBTreeRotationsTrait:
    rotate_right
    rotate_left