### PR TITLE
B 10 pending bids fix

### DIFF
--- a/src/library/red_black_tree.cairo
+++ b/src/library/red_black_tree.cairo
@@ -52,6 +52,7 @@ pub mod RBTreeComponent {
                 let root_node = self.create_root_node(@value);
                 self.tree.write(new_node_id, root_node);
                 self.root.write(new_node_id);
+                self.nonce.write(self.nonce.read() + 1);
                 return;
             }
 
@@ -84,7 +85,9 @@ pub mod RBTreeComponent {
     }
 
     #[generate_trait]
-    pub impl RBTreeOptionRoundImpl<TContractState, +HasComponent<TContractState>> of RBTreeOptionRoundTrait<TContractState> {
+    pub impl RBTreeOptionRoundImpl<
+        TContractState, +HasComponent<TContractState>
+    > of RBTreeOptionRoundTrait<TContractState> {
         fn find_clearing_price(ref self: ComponentState<TContractState>) -> (u256, u256) {
             let total_options_available = self._get_total_options_available();
             let root: felt252 = self.root.read();
@@ -151,7 +154,9 @@ pub mod RBTreeComponent {
     }
 
     #[generate_trait]
-    impl RBTreeOperationsImpl<TContractState, +HasComponent<TContractState>> of RBTreeOperationsTrait<TContractState> {
+    impl RBTreeOperationsImpl<
+        TContractState, +HasComponent<TContractState>
+    > of RBTreeOperationsTrait<TContractState> {
         fn create_root_node(self: @ComponentState<TContractState>, value: @Bid) -> Node {
             Node { value: *value, left: 0, right: 0, parent: 0, color: BLACK, }
         }
@@ -247,7 +252,9 @@ pub mod RBTreeComponent {
     }
 
     #[generate_trait]
-    pub impl RBTreeTestingImpl<TContractState, +HasComponent<TContractState>> of RBTreeTestingTrait<TContractState> {
+    pub impl RBTreeTestingImpl<
+        TContractState, +HasComponent<TContractState>
+    > of RBTreeTestingTrait<TContractState> {
         fn _get_tree_structure(
             self: @ComponentState<TContractState>
         ) -> Array<Array<(u256, bool, u128)>> {

--- a/src/option_round/contract.cairo
+++ b/src/option_round/contract.cairo
@@ -8,9 +8,7 @@ mod OptionRound {
         ERC20Component, interface::{ERC20ABIDispatcher, ERC20ABIDispatcherTrait, IERC20Metadata},
     };
     use pitch_lake_starknet::{
-        library::{
-            utils::{max, min}, red_black_tree::{RBTreeComponent, RBTreeComponent::Node}
-        },
+        library::{utils::{max, min}, red_black_tree::{RBTreeComponent, RBTreeComponent::Node}},
         option_round::interface::IOptionRound,
         vault::{interface::{IVaultDispatcher, IVaultDispatcherTrait},},
         types::{
@@ -350,15 +348,15 @@ mod OptionRound {
 
         // Get the bid ids for all of the bids the option buyer has placed
         fn get_bids_for(self: @ContractState, option_buyer: ContractAddress) -> Array<Bid> {
-            let mut i: u32 = self.bidder_nonces.read(option_buyer);
+            let nonce: u32 = self.bidder_nonces.read(option_buyer);
             let mut bids: Array<Bid> = array![];
-            while i
-                .is_non_zero() {
-                    i -= 1;
-                    let hash = self.create_bid_id(option_buyer, i);
-                    let bid: Bid = self.bids_tree._find(hash);
-                    bids.append(bid);
-                };
+            let mut i = 0;
+            while i < nonce {
+                let hash = self.create_bid_id(option_buyer, i);
+                let bid: Bid = self.bids_tree._find(hash);
+                bids.append(bid);
+                i += 1;
+            };
             bids
         }
 

--- a/src/tests/deployment/constructor_tests.cairo
+++ b/src/tests/deployment/constructor_tests.cairo
@@ -66,7 +66,6 @@ fn test_vault_constructor() {
     assert_eq!(vault.get_round_transition_period(), 'rtp'.try_into().unwrap());
     assert_eq!(vault.get_auction_run_time(), 'art'.try_into().unwrap());
     assert_eq!(vault.get_option_run_time(), 'ort'.try_into().unwrap());
-    assert_eq!(vault.get_cap_level(), 10000);
 
     // Check current round is 1
     assert(current_round_id == 1, 'current round should be 1');

--- a/src/tests/deployment/constructor_tests.cairo
+++ b/src/tests/deployment/constructor_tests.cairo
@@ -66,6 +66,7 @@ fn test_vault_constructor() {
     assert_eq!(vault.get_round_transition_period(), 'rtp'.try_into().unwrap());
     assert_eq!(vault.get_auction_run_time(), 'art'.try_into().unwrap());
     assert_eq!(vault.get_option_run_time(), 'ort'.try_into().unwrap());
+    assert_eq!(vault.get_cap_level(), 10000);
 
     // Check current round is 1
     assert(current_round_id == 1, 'current round should be 1');

--- a/src/tests/misc/lp_token/lp_token_tests.cairo
+++ b/src/tests/misc/lp_token/lp_token_tests.cairo
@@ -105,8 +105,8 @@ fn test_convert_position_to_lp_tokens_success() { //
     // Settle auction
     set_block_timestamp(auction_end_time + 1);
     // Get initial states before conversion
-    let lp1_premiums_init = vault_facade.get_premiums_for(liquidity_provider_1(), 'todo'.into());
-    let lp2_premiums_init = vault_facade.get_premiums_for(liquidity_provider_2(), 'todo'.into());
+    //let lp1_premiums_init = vault_facade.get_premiums_for(liquidity_provider_1(), 'todo'.into());
+    //let lp2_premiums_init = vault_facade.get_premiums_for(liquidity_provider_2(), 'todo'.into());
     let (lp1_collateral_init, _lp1_unallocated_init) = vault_facade
         .get_lp_locked_and_unlocked_balance(liquidity_provider_1());
     let (lp2_collateral_init, lp2_unallocated_init) = vault_facade
@@ -119,8 +119,8 @@ fn test_convert_position_to_lp_tokens_success() { //
     let tokenizing_amount = deposit_amount_wei / 4;
     vault_facade.convert_position_to_lp_tokens(tokenizing_amount, liquidity_provider_1());
     // Get states after conversion
-    let lp1_premiums_final = vault_facade.get_premiums_for(liquidity_provider_1(), 'todo'.into());
-    let lp2_premiums_final = vault_facade.get_premiums_for(liquidity_provider_2(), 'todo'.into());
+    //let lp1_premiums_final = vault_facade.get_premiums_for(liquidity_provider_1(), 'todo'.into());
+    //let lp2_premiums_final = vault_facade.get_premiums_for(liquidity_provider_2(), 'todo'.into());
     let (lp1_collateral_final, lp1_unallocated_final) = vault_facade
         .get_lp_locked_and_unlocked_balance(liquidity_provider_1());
     let (lp2_collateral_final, lp2_unallocated_final) = vault_facade
@@ -131,12 +131,12 @@ fn test_convert_position_to_lp_tokens_success() { //
     //        .get_all_round_liquidity();
     // Assert all premiums were collected (deposit into the next round)
     let expected_premiums_share = current_round.total_premiums() / 2;
-    assert(
-        lp1_premiums_final == lp1_premiums_init
-            - expected_premiums_share && lp1_premiums_final == 0,
-        'lp1 premiums incorrect'
-    ); // @dev need both checks ?
-    assert(lp2_premiums_final == lp2_premiums_init, 'lp2 premiums shd not change');
+    //assert(
+    //    lp1_premiums_final == lp1_premiums_init
+    //        - expected_premiums_share && lp1_premiums_final == 0,
+    //    'lp1 premiums incorrect'
+    //); // @dev need both checks ?
+    //assert(lp2_premiums_final == lp2_premiums_init, 'lp2 premiums shd not change');
     // @dev Some of LP1's collateral is now represented as tokens, this means their collateral will decrease,
     // but the round's will remain the same.
     assert(

--- a/src/tests/option_round/option_buyers/exercise_options_tests.cairo
+++ b/src/tests/option_round/option_buyers/exercise_options_tests.cairo
@@ -132,12 +132,12 @@ fn test_exercise_options_eth_transfer() {
                 let payout_amount = current_round.exercise_options(*ob);
 
                 let lp_balance_after = get_erc20_balance(eth.contract_address, *ob);
-                println!(
-                    "lp_balance_before:{}\nlp_balance_after:{}\npayout_amount:{}",
-                    lp_balance_before,
-                    lp_balance_after,
-                    payout_amount
-                );
+                //println!(
+                //    "lp_balance_before:{}\nlp_balance_after:{}\npayout_amount:{}",
+                //    lp_balance_before,
+                //    lp_balance_after,
+                //    payout_amount
+                //);
                 assert(
                     lp_balance_after == lp_balance_before + payout_amount, 'lp balance after wrong'
                 );

--- a/src/tests/option_round/option_buyers/refunding_bids_tests.cairo
+++ b/src/tests/option_round/option_buyers/refunding_bids_tests.cairo
@@ -78,6 +78,7 @@ fn place_incremental_bids_internal(
 
     // Place bids
     current_round.place_bids(bid_amounts.span(), bid_prices.span(), option_bidders);
+
     (bid_amounts.span(), bid_prices.span(), current_round)
 }
 

--- a/src/tests/option_round/rb_tree/rb_tree_stress_tests.cairo
+++ b/src/tests/option_round/rb_tree/rb_tree_stress_tests.cairo
@@ -18,9 +18,7 @@ use pitch_lake_starknet::{
 fn test_add_1_to_100_delete_100_to_1() {
     let rb_tree = setup_rb_tree_test();
     let mut i = 1;
-    while
-    i <= 100
-    {
+    while i <= 100 {
         insert(rb_tree, i, i.try_into().unwrap());
         println!("Inserted: {:?}", i);
         let is_tree_valid = rb_tree.is_tree_valid();
@@ -29,9 +27,7 @@ fn test_add_1_to_100_delete_100_to_1() {
     };
 
     i = 100;
-    while
-    i >= 1
-    {
+    while i >= 1 {
         let id = poseidon::poseidon_hash_span(
             array![mock_address(MOCK_ADDRESS).into(), i.try_into().unwrap()].span()
         );
@@ -52,9 +48,7 @@ fn test_add_1_to_100_delete_100_to_1() {
 fn test_add_1_to_100_delete_1_to_100() {
     let rb_tree = setup_rb_tree_test();
     let mut i = 1;
-    while
-    i <= 100
-    {
+    while i <= 100 {
         insert(rb_tree, i, i.try_into().unwrap());
         println!("Inserted: {:?}", i);
         let is_tree_valid = rb_tree.is_tree_valid();
@@ -63,9 +57,7 @@ fn test_add_1_to_100_delete_1_to_100() {
     };
 
     i = 1;
-    while
-    i <= 100
-    {
+    while i <= 100 {
         let id = poseidon::poseidon_hash_span(
             array![mock_address(MOCK_ADDRESS).into(), i.try_into().unwrap()].span()
         );
@@ -101,47 +93,47 @@ fn testing_random_insertion_and_deletion() {
 
     let mut i: u32 = 0;
 
-    while
-    i < no_of_nodes.try_into().unwrap()
-    {
-        let price = random(i.try_into().unwrap());
-        let nonce = i.try_into().unwrap();
+    while i < no_of_nodes
+        .try_into()
+        .unwrap() {
+            let price = random(i.try_into().unwrap());
+            let nonce = i.try_into().unwrap();
 
-        let new_bid = create_bid(price.try_into().unwrap(), nonce);
+            let new_bid = create_bid(price.try_into().unwrap(), nonce);
 
-        rb_tree.insert(new_bid);
+            rb_tree.insert(new_bid);
 
-        inserted_node_ids.append(new_bid.id);
+            inserted_node_ids.append(new_bid.id);
 
-        let bid = rb_tree.find(new_bid.id);
-        println!("Inserting price {}", bid.price);
+            let bid = rb_tree.find(new_bid.id);
+            println!("Inserting price {}", bid.price);
 
-        assert(bid.price == price.try_into().unwrap(), 'Insertion error');
+            assert(bid.price == price.try_into().unwrap(), 'Insertion error');
 
-        let is_tree_valid = rb_tree.is_tree_valid();
-        assert(is_tree_valid, 'Tree is not valid');
+            let is_tree_valid = rb_tree.is_tree_valid();
+            assert(is_tree_valid, 'Tree is not valid');
 
-        i += 1;
-    };
+            i += 1;
+        };
 
     let mut j: u32 = 0;
 
-    while
-    j < no_of_nodes.try_into().unwrap()
-    {
-        let bid_id = inserted_node_ids.at(j);
+    while j < no_of_nodes
+        .try_into()
+        .unwrap() {
+            let bid_id = inserted_node_ids.at(j);
 
-        delete(rb_tree, *bid_id);
+            delete(rb_tree, *bid_id);
 
-        let found_bid = rb_tree.find(*bid_id);
+            let found_bid = rb_tree.find(*bid_id);
 
-        assert(found_bid.id == 0, 'Bid delete error');
+            assert(found_bid.id == 0, 'Bid delete error');
 
-        let is_tree_valid = rb_tree.is_tree_valid();
-        assert(is_tree_valid, 'Tree is not valid');
+            let is_tree_valid = rb_tree.is_tree_valid();
+            assert(is_tree_valid, 'Tree is not valid');
 
-        println!("Deleted node no. {}", j);
+            println!("Deleted node no. {}", j);
 
-        j += 1;
-    }
+            j += 1;
+        }
 }

--- a/src/tests/option_round/rb_tree/rb_tree_tests.cairo
+++ b/src/tests/option_round/rb_tree/rb_tree_tests.cairo
@@ -7,7 +7,8 @@ use pitch_lake_starknet::{
             rb_tree::rb_tree_mock_contract::{
                 IRBTreeMockContractDispatcher, IRBTreeMockContractDispatcherTrait
             }
-        },utils::helpers::setup::setup_rb_tree_test
+        },
+        utils::helpers::setup::setup_rb_tree_test
     },
 };
 
@@ -1278,14 +1279,13 @@ fn compare_tree_structures(
     let mut i = 0;
 
     // Compare outer array
-    while
-    i < actual.len()
-    {
-        let actual_inner = actual[i];
-        let expected_inner = expected[i];
-        compare_inner(actual_inner, expected_inner);
-        i += 1;
-    }
+    while i < actual
+        .len() {
+            let actual_inner = actual[i];
+            let expected_inner = expected[i];
+            compare_inner(actual_inner, expected_inner);
+            i += 1;
+        }
 }
 
 fn compare_inner(actual: @Array<(u256, bool, u128)>, expected: @Array<(u256, bool, u128)>) {
@@ -1295,14 +1295,13 @@ fn compare_inner(actual: @Array<(u256, bool, u128)>, expected: @Array<(u256, boo
 
     let mut i = 0;
 
-    while
-    i < actual.len()
-    {
-        let actual_tuple = *actual[i];
-        let expected_tuple = *expected[i];
-        compare_tuple(actual_tuple, expected_tuple);
-        i += 1;
-    }
+    while i < actual
+        .len() {
+            let actual_tuple = *actual[i];
+            let expected_tuple = *expected[i];
+            compare_tuple(actual_tuple, expected_tuple);
+            i += 1;
+        }
 }
 
 fn compare_tuple(actual: (u256, bool, u128), expected: (u256, bool, u128)) {

--- a/src/tests/option_round/state_transition/auction_end/refundable_bids_tests.cairo
+++ b/src/tests/option_round/state_transition/auction_end/refundable_bids_tests.cairo
@@ -31,13 +31,10 @@ use pitch_lake_starknet::tests::{
 };
 
 
-// Deploy vault and start auction
-// @return The vault facade, eth dispatcher, and span of option bidders
-
-// Place incremental bids
+// Deploy vault, start auction, and place incremental bids
 fn place_incremental_bids_internal(
     ref vault: VaultFacade, option_bidders: Span<ContractAddress>,
-) -> (Span<u256>, Span<u256>, OptionRoundFacade, Span<felt252>) {
+) -> (Span<u256>, Span<u256>, OptionRoundFacade, Span<Bid>) {
     let mut current_round = vault.get_current_round();
     let number_of_option_bidders = option_bidders.len();
     let options_available = current_round.get_total_options_available();
@@ -52,8 +49,8 @@ fn place_incremental_bids_internal(
     let mut bid_amounts = create_array_linear(options_available, bid_prices.len());
 
     // Place bids
-    let bid_ids = current_round.place_bids(bid_amounts.span(), bid_prices.span(), option_bidders);
-    (bid_amounts.span(), bid_prices.span(), current_round, bid_ids.span())
+    let bids = current_round.place_bids(bid_amounts.span(), bid_prices.span(), option_bidders);
+    (bid_amounts.span(), bid_prices.span(), current_round, bids.span())
 }
 
 

--- a/src/tests/utils/facades/sanity_checks.cairo
+++ b/src/tests/utils/facades/sanity_checks.cairo
@@ -60,16 +60,17 @@ fn exercise_options(
     individual_payout
 }
 
-fn place_bid(ref self: OptionRoundFacade, bidder: ContractAddress, id: felt252) -> felt252 {
-    let nonce: felt252 = (self.get_bidding_nonce_for(bidder) - 1).into();
-    let hash = poseidon::poseidon_hash_span(array![bidder.into(), nonce].span());
-    //assert(hash == id , 'Invalid hash generated');
-    id
-}
-fn update_bid(ref option_round: OptionRoundFacade, bid_id: felt252, bid: Bid) -> Bid {
-    let storage_bid = option_round.get_bid_details(bid_id);
-    //assert(bid == storage_bi, 'Bid Mismatch');
+fn place_bid(ref self: OptionRoundFacade, bid: Bid) -> Bid {
+    let nonce: felt252 = (self.get_bidding_nonce_for(bid.owner) - 1).into();
+    let expected_id = poseidon::poseidon_hash_span(array![bid.owner.into(), nonce].span());
+    assert(bid.id == expected_id, 'Invalid hash generated');
     bid
+}
+
+fn update_bid(ref option_round: OptionRoundFacade, old_bid: Bid, new_bid: Bid) -> Bid {
+    let storage_bid = option_round.get_bid_details(old_bid.id);
+    assert(new_bid == storage_bid, 'Bid Mismatch');
+    new_bid
 }
 
 fn tokenize_options(

--- a/src/tests/utils/facades/sanity_checks.cairo
+++ b/src/tests/utils/facades/sanity_checks.cairo
@@ -138,8 +138,8 @@ fn test_event_testers() {
     event_helpers::assert_event_auction_bid_rejected(
         round.contract_address(), round.contract_address(), 100, 100
     );
-    event_helpers::assert_event_auction_end(round.contract_address(), 100);
-    event_helpers::assert_event_option_settle(round.contract_address(), 100);
+    event_helpers::assert_event_auction_end(round.contract_address(), 100, 100);
+    event_helpers::assert_event_option_settle(round.contract_address(), 100, 100);
     event_helpers::assert_event_option_round_deployed(
         vault.contract_address(), 1, vault.contract_address()
     );

--- a/src/tests/utils/facades/vault_facade.cairo
+++ b/src/tests/utils/facades/vault_facade.cairo
@@ -306,12 +306,6 @@ impl VaultFacadeImpl of VaultFacadeTrait {
         spreads
     }
 
-    fn get_premiums_for(
-        ref self: VaultFacade, liquidity_provider: ContractAddress, round_id: u256
-    ) -> u256 {
-        self.vault_dispatcher.get_premiums_earned(liquidity_provider, round_id)
-    }
-
     // @note add get_premiums_for_multiple()
 
     // For Vault
@@ -387,6 +381,10 @@ impl VaultFacadeImpl of VaultFacadeTrait {
     // @note TODO impl this in contract later
     fn get_round_transition_period(ref self: VaultFacade) -> u64 {
         self.vault_dispatcher.get_round_transition_period()
+    }
+
+    fn get_cap_level(ref self: VaultFacade) -> u16 {
+      self.vault_dispatcher.get_cap_level()
     }
 }
 

--- a/src/tests/utils/facades/vault_facade.cairo
+++ b/src/tests/utils/facades/vault_facade.cairo
@@ -382,9 +382,5 @@ impl VaultFacadeImpl of VaultFacadeTrait {
     fn get_round_transition_period(ref self: VaultFacade) -> u64 {
         self.vault_dispatcher.get_round_transition_period()
     }
-
-    fn get_cap_level(ref self: VaultFacade) -> u16 {
-      self.vault_dispatcher.get_cap_level()
-    }
 }
 

--- a/src/tests/utils/helpers/event_helpers.cairo
+++ b/src/tests/utils/helpers/event_helpers.cairo
@@ -118,11 +118,11 @@ fn assert_event_auction_bid_rejected(
 }
 
 // Check AuctionEnd emits correctly
-fn assert_event_auction_end(option_round_address: ContractAddress, clearing_price: u256) {
+fn assert_event_auction_end(option_round_address: ContractAddress, clearing_price: u256, total_options_sold: u256) {
     match pop_log::<OptionRound::Event>(option_round_address) {
         Option::Some(e) => {
             let expected = OptionRound::Event::AuctionEnded(
-                OptionRound::AuctionEnded { clearing_price }
+                OptionRound::AuctionEnded { clearing_price, total_options_sold }
             );
             assert_events_equal(e, expected);
         },
@@ -132,11 +132,11 @@ fn assert_event_auction_end(option_round_address: ContractAddress, clearing_pric
 
 // Check OptionSettle emits correctly
 // @dev Settlment price is the price determining the payout for the round
-fn assert_event_option_settle(option_round_address: ContractAddress, settlement_price: u256) {
+fn assert_event_option_settle(option_round_address: ContractAddress, total_payout: u256, settlement_price: u256) {
     match pop_log::<OptionRound::Event>(option_round_address) {
         Option::Some(e) => {
             let expected = OptionRound::Event::OptionRoundSettled(
-                OptionRound::OptionRoundSettled { settlement_price }
+                OptionRound::OptionRoundSettled { total_payout, settlement_price }
             );
             assert_events_equal(e, expected);
         },

--- a/src/tests/utils/helpers/event_helpers.cairo
+++ b/src/tests/utils/helpers/event_helpers.cairo
@@ -118,7 +118,9 @@ fn assert_event_auction_bid_rejected(
 }
 
 // Check AuctionEnd emits correctly
-fn assert_event_auction_end(option_round_address: ContractAddress, clearing_price: u256, total_options_sold: u256) {
+fn assert_event_auction_end(
+    option_round_address: ContractAddress, clearing_price: u256, total_options_sold: u256
+) {
     match pop_log::<OptionRound::Event>(option_round_address) {
         Option::Some(e) => {
             let expected = OptionRound::Event::AuctionEnded(
@@ -132,7 +134,9 @@ fn assert_event_auction_end(option_round_address: ContractAddress, clearing_pric
 
 // Check OptionSettle emits correctly
 // @dev Settlment price is the price determining the payout for the round
-fn assert_event_option_settle(option_round_address: ContractAddress, total_payout: u256, settlement_price: u256) {
+fn assert_event_option_settle(
+    option_round_address: ContractAddress, total_payout: u256, settlement_price: u256
+) {
     match pop_log::<OptionRound::Event>(option_round_address) {
         Option::Some(e) => {
             let expected = OptionRound::Event::OptionRoundSettled(

--- a/src/tests/utils/helpers/setup.cairo
+++ b/src/tests/utils/helpers/setup.cairo
@@ -109,7 +109,6 @@ fn deploy_vault(vault_type: VaultType, eth_address: ContractAddress) -> IVaultDi
     calldata.append_serde('rtp');
     calldata.append_serde('art');
     calldata.append_serde('ort');
-    calldata.append_serde(10000);
     calldata.append_serde(eth_address);
     calldata.append_serde(vault_manager());
     calldata.append_serde(vault_type);

--- a/src/tests/utils/helpers/setup.cairo
+++ b/src/tests/utils/helpers/setup.cairo
@@ -109,6 +109,7 @@ fn deploy_vault(vault_type: VaultType, eth_address: ContractAddress) -> IVaultDi
     calldata.append_serde('rtp');
     calldata.append_serde('art');
     calldata.append_serde('ort');
+    calldata.append_serde(10000);
     calldata.append_serde(eth_address);
     calldata.append_serde(vault_manager());
     calldata.append_serde(vault_type);

--- a/src/tests/utils/helpers/setup.cairo
+++ b/src/tests/utils/helpers/setup.cairo
@@ -11,8 +11,7 @@ use openzeppelin::{
     token::erc20::{ERC20Component, interface::{ERC20ABIDispatcher, ERC20ABIDispatcherTrait,}}
 };
 use pitch_lake_starknet::{
-    types::{StartAuctionParams, OptionRoundState, VaultType},
-    library::{eth::Eth},
+    types::{StartAuctionParams, OptionRoundState, VaultType}, library::{eth::Eth},
     vault::{contract::Vault, interface::{IVaultDispatcher, IVaultDispatcherTrait}},
     option_round::{
         contract::OptionRound,

--- a/src/tests/vault/state_transition/auction_end_tests.cairo
+++ b/src/tests/vault/state_transition/auction_end_tests.cairo
@@ -125,11 +125,11 @@ fn test_auction_ended_option_round_event() {
 
         // End auction
         clear_event_logs(array![current_round.contract_address()]);
-        let (clearing_price, _) = timeskip_and_end_auction(ref vault);
+        let (clearing_price, total_options_sold) = timeskip_and_end_auction(ref vault);
 
         // Check the event emits correctly
         assert(clearing_price > 0, 'clearing price shd be > 0');
-        assert_event_auction_end(current_round.contract_address(), clearing_price);
+        assert_event_auction_end(current_round.contract_address(), clearing_price, total_options_sold);
 
         accelerate_to_settled(ref vault, 0);
         rounds_to_run -= 1;

--- a/src/tests/vault/state_transition/auction_end_tests.cairo
+++ b/src/tests/vault/state_transition/auction_end_tests.cairo
@@ -129,7 +129,9 @@ fn test_auction_ended_option_round_event() {
 
         // Check the event emits correctly
         assert(clearing_price > 0, 'clearing price shd be > 0');
-        assert_event_auction_end(current_round.contract_address(), clearing_price, total_options_sold);
+        assert_event_auction_end(
+            current_round.contract_address(), clearing_price, total_options_sold
+        );
 
         accelerate_to_settled(ref vault, 0);
         rounds_to_run -= 1;

--- a/src/tests/vault/state_transition/option_settle_tests.cairo
+++ b/src/tests/vault/state_transition/option_settle_tests.cairo
@@ -114,9 +114,9 @@ fn test_option_round_settled_event() {
         let mut round = vault.get_current_round();
         let settlement_price = round.get_strike_price() + rounds_to_run.into();
         clear_event_logs(array![round.contract_address()]);
-        accelerate_to_settled(ref vault, settlement_price);
+        let total_payout = accelerate_to_settled(ref vault, settlement_price);
         // Check the event emits correctly
-        assert_event_option_settle(round.contract_address(), settlement_price);
+        assert_event_option_settle(round.contract_address(), total_payout, settlement_price);
 
         rounds_to_run -= 1;
     }

--- a/src/types.cairo
+++ b/src/types.cairo
@@ -21,6 +21,8 @@ mod Errors {
     const BiddingWhileNotAuctioning: felt252 = 'Can only bid while auctioning';
     const CallerNotBidOwner: felt252 = 'Caller is not bid owner';
     const BidCannotBeDecreased: felt252 = 'A bid cannot decrease';
+    /// Other Errors ///
+    const BidsShouldNotHaveSameTreeNonce: felt252 = 'Tree nonces should be unique';
 }
 
 /// An enum for each type of Vault
@@ -92,6 +94,7 @@ impl BidPartialOrdTrait of PartialOrd<Bid> {
         } else if lhs.price > rhs.price {
             false
         } else {
+            assert(lhs.nonce != rhs.nonce, Errors::BidsShouldNotHaveSameTreeNonce);
             lhs.nonce > rhs.nonce
         }
     }
@@ -103,6 +106,7 @@ impl BidPartialOrdTrait of PartialOrd<Bid> {
         } else if lhs.price < rhs.price {
             false
         } else {
+            assert(lhs.nonce != rhs.nonce, Errors::BidsShouldNotHaveSameTreeNonce);
             lhs.nonce < rhs.nonce
         }
     }

--- a/src/vault/contract.cairo
+++ b/src/vault/contract.cairo
@@ -20,44 +20,6 @@ mod Vault {
         }
     };
 
-    // The type of vault
-    // Events
-    #[event]
-    #[derive(PartialEq, Drop, starknet::Event)]
-    enum Event {
-        Deposit: Deposit,
-        Withdrawal: Withdrawal,
-        OptionRoundDeployed: OptionRoundDeployed,
-    }
-
-
-    #[derive(Drop, starknet::Event, PartialEq)]
-    struct Deposit {
-        #[key]
-        account: ContractAddress,
-        position_balance_before: u256,
-        position_balance_after: u256,
-    }
-
-    #[derive(Drop, starknet::Event, PartialEq)]
-    struct Withdrawal {
-        #[key]
-        account: ContractAddress,
-        position_balance_before: u256,
-        position_balance_after: u256,
-    }
-
-
-    #[derive(Drop, starknet::Event, PartialEq)]
-    struct OptionRoundDeployed {
-        // might not need
-        round_id: u256,
-        address: ContractAddress,
-    // option_round_params: OptionRoundParams
-    // possibly more members to this event
-    }
-
-
     // *************************************************************************
     //                              STORAGE
     // *************************************************************************
@@ -74,7 +36,6 @@ mod Vault {
     // @round_addresses: Mapping of round id -> round address
     // @round_transition_period: Time between settling of current round and starting of next round
     // @auction_run_time: running time for the auction
-    //
     #[storage]
     struct Storage {
         eth_address: ContractAddress,
@@ -93,14 +54,19 @@ mod Vault {
         round_transition_period: u64,
         auction_run_time: u64,
         option_run_time: u64,
+        cap_level: u16,
     }
 
+    // *************************************************************************
+    //                              Constructor
+    // *************************************************************************
     #[constructor]
     fn constructor(
         ref self: ContractState,
         round_transition_period: u64,
         auction_run_time: u64,
         option_run_time: u64,
+        cap_level: u16,
         eth_address: ContractAddress,
         vault_manager: ContractAddress,
         vault_type: VaultType,
@@ -112,20 +78,54 @@ mod Vault {
         self.vault_type.write(vault_type);
         self.market_aggregator.write(market_aggregator);
         self.option_round_class_hash.write(option_round_class_hash);
-
-        // Setting placeholder values for storage vars because if left as 0
-        // tests fail that should not
-        // @note Should pass these in the constructor
-        // - Need to update the setup functions to accomodate (and a couple tests)
         self.round_transition_period.write(round_transition_period);
         self.auction_run_time.write(auction_run_time);
         self.option_run_time.write(option_run_time);
+        self.cap_level.write(cap_level);
 
         // @dev Deploy the 1st option round
         self.deploy_next_round();
     }
 
+    // *************************************************************************
+    //                              EVENTS
+    // *************************************************************************
+    #[event]
+    #[derive(PartialEq, Drop, starknet::Event)]
+    enum Event {
+        Deposit: Deposit,
+        Withdrawal: Withdrawal,
+        OptionRoundDeployed: OptionRoundDeployed,
+    }
 
+    #[derive(Drop, starknet::Event, PartialEq)]
+    struct Deposit {
+        #[key]
+        account: ContractAddress,
+        position_balance_before: u256,
+        position_balance_after: u256,
+    }
+
+    #[derive(Drop, starknet::Event, PartialEq)]
+    struct Withdrawal {
+        #[key]
+        account: ContractAddress,
+        position_balance_before: u256,
+        position_balance_after: u256,
+    }
+
+    #[derive(Drop, starknet::Event, PartialEq)]
+    struct OptionRoundDeployed {
+        // might not need
+        round_id: u256,
+        address: ContractAddress,
+    // option_round_params: OptionRoundParams
+    // possibly more members to this event
+    }
+
+    // *************************************************************************
+    //                            IMPLEMENTATION
+    // *************************************************************************
     #[abi(embed_v0)]
     impl VaultImpl of IVault<ContractState> {
         fn rm_me2(ref self: ContractState) {
@@ -159,7 +159,9 @@ mod Vault {
                 );
         }
 
-        /// Reads ///
+        // ***********************************
+        //               READS
+        // ***********************************
 
         /// Other
 
@@ -191,8 +193,11 @@ mod Vault {
             self.round_transition_period.read()
         }
 
+        fn get_cap_level(self: @ContractState) -> u16 {
+            self.cap_level.read()
+        }
 
-        /// Rounds
+        /// Rounds ///
 
         fn current_option_round_id(self: @ContractState) -> u256 {
             self.current_option_round_id.read()
@@ -208,9 +213,7 @@ mod Vault {
             self.unsold_liquidity.read(round_id)
         }
 
-        /// Liquidity
-
-        // For liquidity providers
+        /// Liquidity ///
 
         // Get the value of a liquidity provider's position that is locked
         fn get_lp_locked_balance(
@@ -265,8 +268,6 @@ mod Vault {
                 + self.get_lp_unlocked_balance(liquidity_provider)
         }
 
-        // For Vault //
-
         fn get_total_locked_balance(self: @ContractState) -> u256 {
             self.total_locked_balance.read()
         }
@@ -279,13 +280,7 @@ mod Vault {
             self.get_total_locked_balance() + self.get_total_unlocked_balance()
         }
 
-        /// Premiums
-
-        fn get_premiums_earned(
-            self: @ContractState, liquidity_provider: ContractAddress, round_id: u256
-        ) -> u256 {
-            100
-        }
+        /// Premiums ///
 
         fn get_premiums_collected(
             self: @ContractState, liquidity_provider: ContractAddress, round_id: u256
@@ -293,9 +288,11 @@ mod Vault {
             self.premiums_collected.read((liquidity_provider, round_id))
         }
 
-        /// Writes ///
+        // ***********************************
+        //               WRITES
+        // ***********************************
 
-        /// State transition
+        /// State Transition ///
 
         fn start_auction(ref self: ContractState) -> u256 {
             // Get a dispatcher for the current option round
@@ -411,9 +408,8 @@ mod Vault {
             total_payout
         }
 
-        /// Liquidity provider functions
+        /// Liquidity Provider ///
 
-        // Caller deposits liquidity on behalf of the liquidity provider for the upcoming round
         fn deposit_liquidity(
             ref self: ContractState, amount: u256, liquidity_provider: ContractAddress
         ) -> u256 {
@@ -458,7 +454,6 @@ mod Vault {
             lp_unlocked_balance_after
         }
 
-        // Caller withdraws liquidity from their unlocked balance
         fn withdraw_liquidity(ref self: ContractState, amount: u256) -> u256 {
             // Get the liquidity provider's unlocked balance broken up into its components
             let liquidity_provider = get_caller_address();
@@ -544,7 +539,7 @@ mod Vault {
             updated_lp_unlocked_balance
         }
 
-        /// LP token related
+        /// OTHER (FOR NOW) ///
 
         fn convert_position_to_lp_tokens(ref self: ContractState, amount: u256) {}
 
@@ -559,8 +554,9 @@ mod Vault {
         }
     }
 
-
-    // Internal Functions
+    // *************************************************************************
+    //                          INTERNAL FUNCTIONS
+    // *************************************************************************
     #[generate_trait]
     impl InternalImpl of VaultInternalTrait {
         // Get a dispatcher for the ETH contract

--- a/src/vault/contract.cairo
+++ b/src/vault/contract.cairo
@@ -54,7 +54,6 @@ mod Vault {
         round_transition_period: u64,
         auction_run_time: u64,
         option_run_time: u64,
-        cap_level: u16,
     }
 
     // *************************************************************************
@@ -66,7 +65,6 @@ mod Vault {
         round_transition_period: u64,
         auction_run_time: u64,
         option_run_time: u64,
-        cap_level: u16,
         eth_address: ContractAddress,
         vault_manager: ContractAddress,
         vault_type: VaultType,
@@ -81,7 +79,6 @@ mod Vault {
         self.round_transition_period.write(round_transition_period);
         self.auction_run_time.write(auction_run_time);
         self.option_run_time.write(option_run_time);
-        self.cap_level.write(cap_level);
 
         // @dev Deploy the 1st option round
         self.deploy_next_round();
@@ -191,10 +188,6 @@ mod Vault {
 
         fn get_round_transition_period(self: @ContractState) -> u64 {
             self.round_transition_period.read()
-        }
-
-        fn get_cap_level(self: @ContractState) -> u16 {
-            self.cap_level.read()
         }
 
         /// Rounds ///

--- a/src/vault/interface.cairo
+++ b/src/vault/interface.cairo
@@ -38,10 +38,6 @@ trait IVault<TContractState> {
     // Get the amount of time till starting the next round's auction
     fn get_round_transition_period(self: @TContractState) -> u64;
 
-    // Get the cap level of the vault
-    fn get_cap_level(self: @TContractState) -> u16;
-
-
     // @note Add getters for auction run time & option run time
     // - need to also add to facade, then use in tests for the (not yet created) setters (A1.1)
 

--- a/src/vault/interface.cairo
+++ b/src/vault/interface.cairo
@@ -38,6 +38,9 @@ trait IVault<TContractState> {
     // Get the amount of time till starting the next round's auction
     fn get_round_transition_period(self: @TContractState) -> u64;
 
+    // Get the cap level of the vault
+    fn get_cap_level(self: @TContractState) -> u16;
+
 
     // @note Add getters for auction run time & option run time
     // - need to also add to facade, then use in tests for the (not yet created) setters (A1.1)
@@ -76,17 +79,6 @@ trait IVault<TContractState> {
 
     /// Premiums
 
-    // Get the total premium LP has earned in the current round
-    // @note premiums for previous rounds
-    // @note, not sure this function is easily implementable, if a user accuates their position, the
-    // storage mappings would not be able to correclty value the position in the round_id, to know the
-    // amount of premiums earned in the round_id. We would need to modify the checkpoints to be a mapping
-    // instead of a single value (i.e. checkpoint 1 == x, checkpoint 2 == y, along with keeping track of
-    // the checkpoint nonces)
-    fn get_premiums_earned(
-        self: @TContractState, liquidity_provider: ContractAddress, round_id: u256
-    ) -> u256;
-
     // Get the total premiums collected by an LP in a round
     fn get_premiums_collected(
         self: @TContractState, liquidity_provider: ContractAddress, round_id: u256
@@ -116,7 +108,7 @@ trait IVault<TContractState> {
 
     /// LP functions
 
-    // Liquditiy provider deposits to the vault for the upcoming round
+    // Caller withdraws liquidity from their unlocked balance
     // @return The liquidity provider's updated unlocked position
     fn deposit_liquidity(
         ref self: TContractState, amount: u256, liquidity_provider: ContractAddress
@@ -127,8 +119,6 @@ trait IVault<TContractState> {
     fn withdraw_liquidity(ref self: TContractState, amount: u256) -> u256;
 
     /// LP token related
-
-    // Phase C ?
 
     // LP converts their collateral into LP tokens
     // @note all at once or can LP convert a partial amount ?


### PR DESCRIPTION
- fixed get_bids_for to return a bid array in the correct order (1, 2, 3 instead of 3, 2, 1)
- added a few tests dealing with getting bid arrays for bidders
- also added tests ensuring bid arrays are correct when bids are updated
- updated place_bid(s) to return Bid (Array<Bid>) instead of just the bid id
- uncommented out/updated place/update bid sanity checks
- re organized the contracts a little to match prod. quality
- fixed a bug in the RB tree where adding the root node was not incrementing the bid nonce
- added assertion to ensure tree nonces are always unique
- added additional fields to events (total options sold to AuctionEnded & total payout to OptionRoundSettled)
- removed get_premiums_for. this function would be expensive/complex to implement and if this data is desired it can be computed off chain through an indexer