### PR TITLE
Reenable sanity checks

### DIFF
--- a/src/tests/utils/facades/sanity_checks.cairo
+++ b/src/tests/utils/facades/sanity_checks.cairo
@@ -28,7 +28,7 @@ use pitch_lake_starknet::{
 
 fn start_auction(ref option_round: OptionRoundFacade, total_options_available: u256) -> u256 {
     let expected = option_round.get_total_options_available();
-    //assert(expected == total_options_available, 'Auction start sanity check fail');
+    assert(expected == total_options_available, 'Auction start sanity check fail');
     total_options_available
 }
 
@@ -37,26 +37,26 @@ fn end_auction(
 ) -> (u256, u256) {
     let expected1 = option_round.get_auction_clearing_price();
     let expected2 = option_round.total_options_sold();
-    //assert(expected1 == clearing_price, 'Auction end sanity check fail 1');
+    assert(expected1 == clearing_price, 'Auction end sanity check fail 1');
     assert(expected2 == total_options_sold, 'Auction end sanity check fail 2');
     (clearing_price, total_options_sold)
 }
 
 fn settle_option_round(ref option_round: OptionRoundFacade, total_payout: u256) -> u256 {
     let expected = option_round.total_payout();
-    //assert(expected == total_payout, 'Settle round sanity check fail');
+    assert(expected == total_payout, 'Settle round sanity check fail');
     total_payout
 }
 
 fn refund_bid(ref option_round: OptionRoundFacade, refund_amount: u256, expected: u256) -> u256 {
-    //assert(refund_amount == expected, 'Refund sanity check fail');
+    assert(refund_amount == expected, 'Refund sanity check fail');
     refund_amount
 }
 
 fn exercise_options(
     ref option_round: OptionRoundFacade, individual_payout: u256, expected: u256
 ) -> u256 {
-    //assert(individual_payout == expected, 'Exercise opts sanity check fail');
+    assert(individual_payout == expected, 'Exercise opts sanity check fail');
     individual_payout
 }
 
@@ -82,10 +82,10 @@ fn tokenize_options(
     let option_erc20_balance_after = get_erc20_balance(
         option_round.contract_address(), option_bidder
     );
-    //    assert(
-    //      option_erc20_balance_after == option_erc20_balance_before + options_minted,
-    //      'ERC20 Balance Mismatch'
-    //    );
+       assert(
+         option_erc20_balance_after == option_erc20_balance_before + options_minted,
+         'ERC20 Balance Mismatch'
+       );
     options_minted
 }
 


### PR DESCRIPTION
I observe that the no of tests that are passing before and after enabling sanity checks is same.