### PR TITLE
Fossil client callback settles round

### DIFF
--- a/src/fossil_client/contract.cairo
+++ b/src/fossil_client/contract.cairo
@@ -7,7 +7,7 @@ mod FossilClient {
     use pitch_lake::library::constants::PROGRAM_ID;
     use pitch_lake::vault::interface::{IVaultDispatcher, IVaultDispatcherTrait};
     use pitch_lake::option_round::interface::{IOptionRoundDispatcher, IOptionRoundDispatcherTrait};
-    use pitch_lake::fossil_client::interface::{JobRequest, FossilResult, L1Data, IFossilClient,};
+    use pitch_lake::fossil_client::interface::{JobRequest, FossilResult, L1Data, IFossilClient, FossilCallbackReturn};
 
     // *************************************************************************
     //                              STORAGE
@@ -63,7 +63,7 @@ mod FossilClient {
     impl FossilClientImpl of IFossilClient<ContractState> {
         fn fossil_callback(
             ref self: ContractState, mut request: Span<felt252>, mut result: Span<felt252>
-        ) {
+        ) -> FossilCallbackReturn {
             // Deserialize request & result
             let JobRequest { vault_address, timestamp, program_id } = Serde::deserialize(
                 ref request
@@ -89,15 +89,7 @@ mod FossilClient {
 
             // Relay L1 data to the vault
             IVaultDispatcher { contract_address: vault_address }
-                .fossil_client_callback(l1_data, timestamp);
-
-            // Emit callback success event
-            self
-                .emit(
-                    Event::FossilCallbackSuccess(
-                        FossilCallbackSuccess { vault_address, l1_data, timestamp }
-                    )
-                );
+                .fossil_client_callback(l1_data, timestamp)
         }
     }
 }

--- a/src/fossil_client/interface.cairo
+++ b/src/fossil_client/interface.cairo
@@ -6,7 +6,7 @@ use starknet::{ContractAddress, StorePacking};
 
 #[starknet::interface]
 trait IFossilClient<TContractState> {
-    fn fossil_callback(ref self: TContractState, request: Span<felt252>, result: Span<felt252>);
+    fn fossil_callback(ref self: TContractState, request: Span<felt252>, result: Span<felt252>) -> FossilCallbackReturn;
 }
 
 // *************************************************************************
@@ -46,6 +46,17 @@ struct FossilResult {
     l1_data: L1Data,
     // Place holder for proof data
     proof: Span<felt252>,
+}
+
+#[derive(Copy, Drop, Serde)]
+enum FossilCallbackReturn {
+    RoundSettled: RoundSettledReturn,
+    FirstRoundInitialized,
+}
+  
+#[derive(Copy, Drop, Serde)]
+struct RoundSettledReturn{ 
+    total_payout: u256
 }
 
 impl SerdeFossilResult of Serde<FossilResult> {

--- a/src/tests.cairo
+++ b/src/tests.cairo
@@ -72,6 +72,7 @@ mod utils {
         mod accelerators;
         mod event_helpers;
         mod general_helpers;
+        mod fossil_client_helpers;
         mod setup;
     }
 

--- a/src/tests/option_round/state_transition/auction_end/option_distribution_tests.cairo
+++ b/src/tests/option_round/state_transition/auction_end/option_distribution_tests.cairo
@@ -7,7 +7,7 @@ use pitch_lake::tests::{
         helpers::{
             accelerators::{
                 accelerate_to_auctioning, accelerate_to_auctioning_custom, accelerate_to_running,
-                accelerate_to_running_custom, timeskip_and_settle_round, timeskip_and_end_auction,
+                accelerate_to_running_custom, timeskip_and_end_auction,
                 //accelerate_to_running_custom_option_round,
             },
             setup::{setup_facade, setup_test_auctioning_bidders},

--- a/src/tests/option_round/state_transition/caller_is_not_vault_tests.cairo
+++ b/src/tests/option_round/state_transition/caller_is_not_vault_tests.cairo
@@ -13,7 +13,7 @@ use pitch_lake::{
             helpers::{
                 accelerators::{
                     accelerate_to_auctioning, accelerate_to_running, accelerate_to_running_custom,
-                    accelerate_to_settled, clear_event_logs, timeskip_and_settle_round
+                    accelerate_to_settled, clear_event_logs
                 },
                 setup::{FOSSIL_PROCESSOR, setup_facade, deploy_vault, deploy_eth},
                 event_helpers::{assert_fossil_callback_success_event}, general_helpers::{to_gwei},

--- a/src/tests/utils/facades/fossil_client_facade.cairo
+++ b/src/tests/utils/facades/fossil_client_facade.cairo
@@ -1,6 +1,6 @@
 use crate::fossil_client::interface::{
     IFossilClientDispatcher, IFossilClientSafeDispatcher, IFossilClientDispatcherTrait,
-    IFossilClientSafeDispatcherTrait
+    IFossilClientSafeDispatcherTrait, FossilCallbackReturn
 };
 use crate::tests::utils::helpers::setup::FOSSIL_PROCESSOR;
 use starknet::testing::set_contract_address;
@@ -27,9 +27,9 @@ impl FossilClientFacadeImpl of FossilClientFacadeTrait {
     }
 
     /// Entrypoints
-    fn fossil_callback(self: FossilClientFacade, request: Span<felt252>, result: Span<felt252>) {
+    fn fossil_callback(self: FossilClientFacade, request: Span<felt252>, result: Span<felt252>) -> FossilCallbackReturn {
         set_contract_address(FOSSIL_PROCESSOR());
-        self.dispatcher().fossil_callback(request, result);
+        self.dispatcher().fossil_callback(request, result)
     }
 
     #[feature("safe_dispatcher")]

--- a/src/tests/utils/facades/vault_facade.cairo
+++ b/src/tests/utils/facades/vault_facade.cairo
@@ -1,7 +1,7 @@
 use starknet::{ContractAddress, testing::{set_contract_address, set_block_timestamp}};
 use openzeppelin_token::erc20::interface::{ERC20ABIDispatcher, ERC20ABIDispatcherTrait};
 use pitch_lake::{
-    fossil_client::interface::{JobRequest, L1Data, FossilResult},
+    fossil_client::interface::{JobRequest, L1Data, FossilResult, FossilCallbackReturn, RoundSettledReturn},
     vault::{
         interface::{
             VaultType, IVaultDispatcher, IVaultDispatcherTrait, IVaultSafeDispatcher,
@@ -162,7 +162,7 @@ impl VaultFacadeImpl of VaultFacadeTrait {
 
     /// State transition
 
-    fn fossil_client_callback(ref self: VaultFacade, l1_data: L1Data, timestamp: u64) {
+    fn fossil_client_callback(ref self: VaultFacade, l1_data: L1Data, timestamp: u64) -> FossilCallbackReturn {
         self.vault_dispatcher.fossil_client_callback(l1_data, timestamp);
     }
 
@@ -205,26 +205,26 @@ impl VaultFacadeImpl of VaultFacadeTrait {
         safe_vault.end_auction().expect_err(error);
     }
 
-    fn settle_option_round(ref self: VaultFacade) -> u256 {
-        // @dev Using bystander as caller so that gas fees do not throw off balance calculations
-        set_contract_address(bystander());
+    // fn settle_option_round(ref self: VaultFacade) -> u256 {
+    //     // @dev Using bystander as caller so that gas fees do not throw off balance calculations
+    //     set_contract_address(bystander());
 
-        // Settle the current round
-        let mut current_round = self.get_current_round();
-        let total_payout = self.vault_dispatcher.settle_round();
-        let total_payout = sanity_checks::settle_option_round(ref current_round, total_payout);
+    //     // Settle the current round
+    //     let mut current_round = self.get_current_round();
+    //     let total_payout = self.vault_dispatcher.settle_round();
+    //     let total_payout = sanity_checks::settle_option_round(ref current_round, total_payout);
 
-        let current_round_address = self.get_option_round_address(self.get_current_round_id());
-        eth_supply_and_approve_all_bidders(current_round_address, self.get_eth_address());
-        total_payout
-    }
+    //     let current_round_address = self.get_option_round_address(self.get_current_round_id());
+    //     eth_supply_and_approve_all_bidders(current_round_address, self.get_eth_address());
+    //     total_payout
+    // }
 
-    #[feature("safe_dispatcher")]
-    fn settle_option_round_expect_error(ref self: VaultFacade, error: felt252) {
-        set_contract_address(bystander());
-        let safe_vault = self.get_safe_dispatcher();
-        safe_vault.settle_round().expect_err(error);
-    }
+    // #[feature("safe_dispatcher")]
+    // fn settle_option_round_expect_error(ref self: VaultFacade, error: felt252) {
+    //     set_contract_address(bystander());
+    //     let safe_vault = self.get_safe_dispatcher();
+    //     safe_vault.settle_round().expect_err(error);
+    // }
 
     /// Fossil
 

--- a/src/tests/utils/facades/vault_facade.cairo
+++ b/src/tests/utils/facades/vault_facade.cairo
@@ -163,7 +163,7 @@ impl VaultFacadeImpl of VaultFacadeTrait {
     /// State transition
 
     fn fossil_client_callback(ref self: VaultFacade, l1_data: L1Data, timestamp: u64) -> FossilCallbackReturn {
-        self.vault_dispatcher.fossil_client_callback(l1_data, timestamp);
+        self.vault_dispatcher.fossil_client_callback(l1_data, timestamp)
     }
 
     #[feature("safe_dispatcher")]

--- a/src/tests/utils/helpers/accelerators.cairo
+++ b/src/tests/utils/helpers/accelerators.cairo
@@ -189,10 +189,10 @@ fn timeskip_and_end_auction(ref self: VaultFacade) -> (u256, u256) {
 }
 
 // Jump to the option expriry date and settle the round
-fn timeskip_and_settle_round(ref self: VaultFacade) -> u256 {
-    let mut current_round = self.get_current_round();
-    set_block_timestamp(current_round.get_option_settlement_date());
-    set_contract_address(bystander());
-    self.settle_option_round()
-}
+// fn timeskip_and_settle_round(ref self: VaultFacade) -> u256 {
+//     let mut current_round = self.get_current_round();
+//     set_block_timestamp(current_round.get_option_settlement_date());
+//     set_contract_address(bystander());
+//     self.settle_option_round()
+// }
 

--- a/src/tests/utils/helpers/accelerators.cairo
+++ b/src/tests/utils/helpers/accelerators.cairo
@@ -24,7 +24,7 @@ use pitch_lake::{
             helpers::{ // accelerators::{accelerate_to_auction_custom_auction_params},
                 event_helpers::{clear_event_logs,},
                 general_helpers::{to_gwei, assert_two_arrays_equal_length, get_erc20_balances},
-                //setup::{deploy_custom_option_round},
+                setup::{eth_supply_and_approve_all_bidders},
             },
             facades::{
                 option_round_facade::{OptionRoundFacade, OptionRoundFacadeTrait},
@@ -111,6 +111,10 @@ fn accelerate_to_settled_custom(ref self: VaultFacade, l1_data: L1Data) -> u256 
         },
         _ => panic!("Expected RoundSettled return")
     };
+
+    // Set the ETH allowance for the next round
+    let current_round_address = self.get_option_round_address(self.get_current_round_id());
+    eth_supply_and_approve_all_bidders(current_round_address, self.get_eth_address());
 
     round_settled_return.total_payout
 }

--- a/src/tests/utils/helpers/fossil_client_helpers.cairo
+++ b/src/tests/utils/helpers/fossil_client_helpers.cairo
@@ -1,0 +1,27 @@
+use pitch_lake::fossil_client::interface::{L1Data, JobRequest, FossilResult};
+use pitch_lake::tests::utils::facades::vault_facade::{VaultFacade, VaultFacadeTrait};
+use pitch_lake::tests::utils::helpers::general_helpers::to_gwei;
+
+fn get_mock_l1_data() -> L1Data {
+    L1Data { twap: to_gwei(33) / 100, volatility: 1009, reserve_price: to_gwei(11) / 10 }
+}
+
+fn get_mock_result() -> FossilResult {
+    FossilResult { proof: array![].span(), l1_data: get_mock_l1_data() }
+}
+
+fn get_mock_result_serialized() -> Span<felt252> {
+    let mut result_serialized = array![];
+    get_mock_result().serialize(ref result_serialized);
+    result_serialized.span()
+}
+
+fn get_request(ref vault: VaultFacade) -> JobRequest {
+    vault.get_request_to_settle_round()
+}
+
+fn get_request_serialized(ref vault: VaultFacade) -> Span<felt252> {
+    let mut request_serialized = array![];
+    get_request(ref vault).serialize(ref request_serialized);
+    request_serialized.span()
+}

--- a/src/tests/vault/liquidity_providers/withdrawal_queue_tests.cairo
+++ b/src/tests/vault/liquidity_providers/withdrawal_queue_tests.cairo
@@ -169,12 +169,14 @@ fn test_stashed_liquidity_does_not_roll_over() {
     let (mut vault, _) = setup_facade();
     let mut current_round = vault.get_current_round();
 
+    println!("Good so far 1");
     /// Deposit 100
     let liquidity_provider = liquidity_provider_1();
     let deposit_amount = 100 * decimals();
     accelerate_to_auctioning_custom(
         ref vault, array![liquidity_provider].span(), array![deposit_amount].span()
     );
+    println!("Good so far 2");
     accelerate_to_running_custom(
         ref vault,
         array![option_bidder_buyer_1()].span(),
@@ -185,15 +187,17 @@ fn test_stashed_liquidity_does_not_roll_over() {
     let premiums = current_round.total_premiums();
     let unsold_liq = vault.get_unsold_liquidity(current_round.get_round_id());
 
+    println!("Good so far 3");
     // Queue 100/100 for stash
     vault.queue_withdrawal(liquidity_provider, 10_000);
+    println!("Good so far 4");
 
     // Start round 2
     let total_payout = accelerate_to_settled(
         ref vault, current_round.get_strike_price()
     ); //no payout
     accelerate_to_auctioning_custom(ref vault, array![].span(), array![].span());
-
+    println!("Good so far 5");
     let (total_locked, total_unlocked, total_stashed) = vault
         .get_total_locked_and_unlocked_and_stashed_balance();
     let lp_stashed = vault.get_lp_stashed_balance(liquidity_provider);
@@ -211,14 +215,16 @@ fn test_stashed_liquidity_does_not_roll_over() {
     let starting_liq2 = current_round2.starting_liquidity();
 
     // Queue withdrawal
+    println!("Good so far 6");
     vault.queue_withdrawal(liquidity_provider, 10_000);
-
+    println!("Good so far 7");
     accelerate_to_running(ref vault);
+    println!("Good so far 8");
     let unsold_liq2 = vault.get_unsold_liquidity(current_round2.get_round_id());
     let total_premiums2 = current_round2.total_premiums();
     let total_payout2 = accelerate_to_settled(ref vault, 1); //no payout
     accelerate_to_auctioning_custom(ref vault, array![].span(), array![].span());
-
+    println!("Good so far 9");
     let (total_locked2, total_unlocked2, total_stashed2) = vault
         .get_total_locked_and_unlocked_and_stashed_balance();
     let lp_stashed2 = vault.get_lp_stashed_balance(liquidity_provider);

--- a/src/tests/vault/liquidity_providers/withdrawal_queue_tests.cairo
+++ b/src/tests/vault/liquidity_providers/withdrawal_queue_tests.cairo
@@ -169,14 +169,12 @@ fn test_stashed_liquidity_does_not_roll_over() {
     let (mut vault, _) = setup_facade();
     let mut current_round = vault.get_current_round();
 
-    println!("Good so far 1");
     /// Deposit 100
     let liquidity_provider = liquidity_provider_1();
     let deposit_amount = 100 * decimals();
     accelerate_to_auctioning_custom(
         ref vault, array![liquidity_provider].span(), array![deposit_amount].span()
     );
-    println!("Good so far 2");
     accelerate_to_running_custom(
         ref vault,
         array![option_bidder_buyer_1()].span(),
@@ -187,17 +185,14 @@ fn test_stashed_liquidity_does_not_roll_over() {
     let premiums = current_round.total_premiums();
     let unsold_liq = vault.get_unsold_liquidity(current_round.get_round_id());
 
-    println!("Good so far 3");
     // Queue 100/100 for stash
     vault.queue_withdrawal(liquidity_provider, 10_000);
-    println!("Good so far 4");
 
     // Start round 2
     let total_payout = accelerate_to_settled(
         ref vault, current_round.get_strike_price()
     ); //no payout
     accelerate_to_auctioning_custom(ref vault, array![].span(), array![].span());
-    println!("Good so far 5");
     let (total_locked, total_unlocked, total_stashed) = vault
         .get_total_locked_and_unlocked_and_stashed_balance();
     let lp_stashed = vault.get_lp_stashed_balance(liquidity_provider);
@@ -215,16 +210,12 @@ fn test_stashed_liquidity_does_not_roll_over() {
     let starting_liq2 = current_round2.starting_liquidity();
 
     // Queue withdrawal
-    println!("Good so far 6");
     vault.queue_withdrawal(liquidity_provider, 10_000);
-    println!("Good so far 7");
     accelerate_to_running(ref vault);
-    println!("Good so far 8");
     let unsold_liq2 = vault.get_unsold_liquidity(current_round2.get_round_id());
     let total_premiums2 = current_round2.total_premiums();
     let total_payout2 = accelerate_to_settled(ref vault, 1); //no payout
     accelerate_to_auctioning_custom(ref vault, array![].span(), array![].span());
-    println!("Good so far 9");
     let (total_locked2, total_unlocked2, total_stashed2) = vault
         .get_total_locked_and_unlocked_and_stashed_balance();
     let lp_stashed2 = vault.get_lp_stashed_balance(liquidity_provider);
@@ -627,7 +618,6 @@ fn test_claiming_queued_liquidity_sets_stashed_to_0() {
     let stashed_balance_after = vault.get_lp_stashed_balance(liquidity_provider);
 
     assert_eq!(stashed_balance_before, (sold_liq * bps.into()) / BPS_u256);
-    println!("stashed_balance_after: {}", stashed_balance_after);
     assert_eq!(stashed_balance_after, 0);
 }
 

--- a/src/tests/vault/state_transition/auction_start_tests.cairo
+++ b/src/tests/vault/state_transition/auction_start_tests.cairo
@@ -22,7 +22,7 @@ use pitch_lake::{
                 accelerators::{
                     accelerate_to_auctioning, accelerate_to_running, accelerate_to_settled,
                     accelerate_to_auctioning_custom, accelerate_to_running_custom,
-                    timeskip_and_settle_round, timeskip_and_end_auction, timeskip_and_start_auction,
+                    timeskip_and_end_auction, timeskip_and_start_auction,
                 },
                 general_helpers::{
                     create_array_linear, create_array_gradient, sum_u256_array,

--- a/src/tests/vault/state_transition/option_settle_tests.cairo
+++ b/src/tests/vault/state_transition/option_settle_tests.cairo
@@ -247,7 +247,7 @@ fn test_settling_option_round_updates_current_round_id() {
 // Test settling an option round updates the current round's state
 // @note should this be a state transition test in option round tests
 #[test]
-#[available_gas(5000000000)]
+#[available_gas(500000000)]
 fn test_settle_option_round_updates_round_state() {
     let mut rounds_to_run = 3;
     let (mut vault, _) = setup_facade();

--- a/src/tests/vault/state_transition/option_settle_tests.cairo
+++ b/src/tests/vault/state_transition/option_settle_tests.cairo
@@ -253,7 +253,6 @@ fn test_settle_option_round_updates_round_state() {
     let (mut vault, _) = setup_facade();
 
     while rounds_to_run > 0_u32 {
-        println!("rounds_to_run: {}", rounds_to_run);
         accelerate_to_auctioning(ref vault);
         accelerate_to_running(ref vault);
         let mut current_round = vault.get_current_round();

--- a/src/tests/vault/state_transition/option_settle_tests.cairo
+++ b/src/tests/vault/state_transition/option_settle_tests.cairo
@@ -35,6 +35,9 @@ use pitch_lake::{
                     deploy_vault_with_events, setup_facade, setup_test_auctioning_providers,
                     setup_test_running, AUCTION_DURATION, ROUND_TRANSITION_DURATION, ROUND_DURATION
                 },
+                fossil_client_helpers::{
+                    get_mock_result_serialized, get_mock_result, get_request, get_request_serialized
+                }
             },
             lib::{
                 test_accounts::{
@@ -46,12 +49,14 @@ use pitch_lake::{
             },
             facades::{
                 vault_facade::{VaultFacade, VaultFacadeTrait},
+                fossil_client_facade::{FossilClientFacade, FossilClientFacadeTrait},
                 option_round_facade::{OptionRoundState, OptionRoundFacade, OptionRoundFacadeTrait},
             },
         },
     }
 };
 use debug::PrintTrait;
+use crate::tests::utils::helpers::setup::FOSSIL_PROCESSOR;
 
 
 /// Failures ///
@@ -65,7 +70,13 @@ fn test_settling_option_round_while_round_auctioning_fails() {
     accelerate_to_auctioning(ref vault_facade);
 
     // Settle option round before auction ends
-    vault_facade.settle_option_round_expect_error(Errors::OptionSettlementDateNotReached);
+    // vault_facade.settle_option_round_expect_error(Errors::OptionSettlementDateNotReached);
+    let request = get_request_serialized(ref vault_facade);
+    let mut result = get_mock_result_serialized();
+    set_contract_address(FOSSIL_PROCESSOR());
+    vault_facade
+        .get_fossil_client_facade()
+        .fossil_callback_expect_error(request, result, Errors::OptionSettlementDateNotReached);
 }
 
 // Test settling an option round before the option expiry date fails
@@ -75,7 +86,13 @@ fn test_settling_option_round_before_settlement_date_fails() {
     let (mut vault_facade, _) = setup_test_running();
 
     // Settle option round before expiry
-    vault_facade.settle_option_round_expect_error(Errors::OptionSettlementDateNotReached);
+    // vault_facade.settle_option_round_expect_error(Errors::OptionSettlementDateNotReached);
+    let request = get_request_serialized(ref vault_facade);
+    let mut result = get_mock_result_serialized();
+    set_contract_address(FOSSIL_PROCESSOR());
+    vault_facade
+        .get_fossil_client_facade()
+        .fossil_callback_expect_error(request, result, Errors::OptionSettlementDateNotReached);
 }
 
 // Test settling an option round while round settled fails
@@ -88,7 +105,13 @@ fn test_settling_option_round_while_settled_fails() {
     accelerate_to_settled(ref vault_facade, 0x123);
 
     // Settle option round after it has already settled
-    vault_facade.settle_option_round_expect_error(Errors::OptionRoundAlreadySettled);
+    // vault_facade.settle_option_round_expect_error(Errors::OptionRoundAlreadySettled);
+    let request = get_request_serialized(ref vault_facade);
+    let mut result = get_mock_result_serialized();
+    set_contract_address(FOSSIL_PROCESSOR());
+    vault_facade
+        .get_fossil_client_facade()
+        .fossil_callback_expect_error(request, result, Errors::OptionRoundAlreadySettled);
 }
 
 /// Event Tests ///
@@ -224,12 +247,13 @@ fn test_settling_option_round_updates_current_round_id() {
 // Test settling an option round updates the current round's state
 // @note should this be a state transition test in option round tests
 #[test]
-#[available_gas(500000000)]
+#[available_gas(5000000000)]
 fn test_settle_option_round_updates_round_state() {
     let mut rounds_to_run = 3;
     let (mut vault, _) = setup_facade();
 
     while rounds_to_run > 0_u32 {
+        println!("rounds_to_run: {}", rounds_to_run);
         accelerate_to_auctioning(ref vault);
         accelerate_to_running(ref vault);
         let mut current_round = vault.get_current_round();

--- a/src/vault/contract.cairo
+++ b/src/vault/contract.cairo
@@ -10,7 +10,7 @@ mod Vault {
         ERC20Component, interface::{ERC20ABIDispatcher, ERC20ABIDispatcherTrait}
     };
     use openzeppelin_utils::serde::SerializedAppend;
-    use pitch_lake::fossil_client::interface::{L1Data, JobRequest};
+    use pitch_lake::fossil_client::interface::{L1Data, JobRequest, FossilCallbackReturn, RoundSettledReturn};
     use pitch_lake::vault::interface::{ConstructorArgs, IVault, VaultType,};
     use pitch_lake::option_round::contract::{OptionRound, OptionRound::Errors as RoundErrors};
     use pitch_lake::option_round::interface::{
@@ -686,13 +686,12 @@ mod Vault {
             amount
         }
 
+        
+
         /// State transitions
-        fn fossil_client_callback(ref self: ContractState, l1_data: L1Data, timestamp: u64) {
+        fn fossil_client_callback(ref self: ContractState, l1_data: L1Data, timestamp: u64) ->  FossilCallbackReturn {
             // @dev Only the Fossil Client contract can call this function
-            assert(
-                get_caller_address() == self.fossil_client_address.read(),
-                Errors::CallerNotFossilClient
-            );
+            self.assert_caller_is_fossil_client();
 
             // @dev Assert the L1 data is valid
             let L1Data { twap, volatility: _, reserve_price } = l1_data;
@@ -720,9 +719,10 @@ mod Vault {
                 // @dev Ensure the job request's timestamp is for the settlement date
                 assert(timestamp == settlement_date, Errors::L1DataOutOfRange);
 
-                // @dev Store l1 data for this round's settlement
-                // @note Could settle round right now instead of storing the results ?
-                self.l1_data.entry(current_round_id).write(l1_data);
+                // @dev Settle the current round
+                let total_payout = self.settle_round(l1_data);
+                
+                FossilCallbackReturn::RoundSettled(RoundSettledReturn { total_payout })
             } // @dev If the first round is Open, the result is being used to set the pricing data for its auction to start
             else {
                 // // @dev Ensure now < auction start date
@@ -738,11 +738,17 @@ mod Vault {
                 // @dev Set the round's pricing data directly
                 current_round.set_pricing_data(pricing_data);
 
-                self.emit(PricingDataSet { 
-                    pricing_data,  // Use the converted data
-                    round_id: current_round_id,
-                    round_address: current_round.contract_address
-                });
+                self
+                    .emit(
+                        PricingDataSet {
+                            pricing_data, // Use the converted data
+                            round_id: current_round_id,
+                            round_address: current_round.contract_address
+                        }
+                    );
+                
+
+                FossilCallbackReturn::FirstRoundInitialized
             }
         }
 
@@ -804,71 +810,6 @@ mod Vault {
             }));
 
             (clearing_price, options_sold)
-        }
-
-        fn settle_round(ref self: ContractState) -> u256 {
-            // @dev Get pricing data set for the current round's settlement
-            let current_round_id = self.current_round_id.read();
-            let L1Data { twap, volatility, reserve_price } = self
-                .l1_data
-                .entry(current_round_id)
-                .read();
-
-            assert(
-                twap.is_non_zero() && reserve_price.is_non_zero(), RoundErrors::PricingDataNotSet
-            );
-
-            // @dev Settle the current round and return the total payout
-            let current_round = self.get_round_dispatcher(current_round_id);
-            let (total_payout, payout_per_option) = current_round.settle_round(twap);
-
-            // @dev Calculate the remaining liquidity after the round settles
-            let starting_liq = current_round.get_starting_liquidity();
-            let unsold_liq = current_round.get_unsold_liquidity();
-            let remaining_liq = starting_liq - unsold_liq - total_payout;
-
-            // @dev Calculate the amount of liquidity that was stashed/not stashed by liquidity
-            // providers, avoiding division by 0
-            let vault = get_contract_address();
-            let starting_liq_queued = self
-                .queued_liquidity
-                .entry(vault)
-                .entry(current_round_id)
-                .read();
-            let remaining_liq_stashed = match starting_liq.is_zero() {
-                true => 0,
-                false => (remaining_liq * starting_liq_queued) / starting_liq
-            };
-            let remaining_liq_not_stashed = remaining_liq - remaining_liq_stashed;
-
-            // @dev All of the remaining liquidity becomes unlocked, any stashed liquidity is
-            // set aside and no longer participates in the protocol
-            self.vault_locked_balance.write(0);
-            self
-                .vault_stashed_balance
-                .write(self.vault_stashed_balance.read() + remaining_liq_stashed);
-            self
-                .vault_unlocked_balance
-                .write(self.vault_unlocked_balance.read() + remaining_liq_not_stashed);
-
-            // @dev Transfer payout from the vault to the just settled round,
-            if (total_payout > 0) {
-                self.get_eth_dispatcher().transfer(current_round.contract_address, total_payout);
-            }
-
-            // @dev Emit event
-            self.emit(Event::OptionRoundSettled(OptionRoundSettled {
-                round_id: current_round_id,
-                round_address: current_round.contract_address,
-                settlement_price: twap,
-                payout_per_option
-            }));
-
-            // @dev Deploy the next option round contract & update the current round id
-            self.deploy_next_round(L1Data { twap, volatility, reserve_price });
-
-            // @dev Return just the total payout
-            total_payout
         }
 
         // Option round user actions
@@ -994,6 +935,13 @@ mod Vault {
         }
 
         /// Basic helpers
+        
+        fn assert_caller_is_fossil_client(self: @ContractState) {
+            assert(
+                get_caller_address() == self.fossil_client_address.read(),
+                Errors::CallerNotFossilClient
+            );
+        }
 
         fn get_upcoming_round_id(self: @ContractState) -> u64 {
             let current_round_id = self.current_round_id.read();
@@ -1072,6 +1020,68 @@ mod Vault {
                 option_settlement_date: round.get_option_settlement_date(),
                 pricing_data,  // Use the converted data
             });
+        }
+
+        fn settle_round(ref self: ContractState, l1_data: L1Data) -> u256 {
+            // @dev Get pricing data set for the current round's settlement
+            let current_round_id = self.current_round_id.read();
+            let L1Data { twap, volatility, reserve_price } = l1_data;
+
+            assert(
+                twap.is_non_zero() && reserve_price.is_non_zero(), RoundErrors::PricingDataNotSet
+            );
+
+            // @dev Settle the current round and return the total payout
+            let current_round = self.get_round_dispatcher(current_round_id);
+            let (total_payout, payout_per_option) = current_round.settle_round(twap);
+
+            // @dev Calculate the remaining liquidity after the round settles
+            let starting_liq = current_round.get_starting_liquidity();
+            let unsold_liq = current_round.get_unsold_liquidity();
+            let remaining_liq = starting_liq - unsold_liq - total_payout;
+
+            // @dev Calculate the amount of liquidity that was stashed/not stashed by liquidity
+            // providers, avoiding division by 0
+            let vault = get_contract_address();
+            let starting_liq_queued = self
+                .queued_liquidity
+                .entry(vault)
+                .entry(current_round_id)
+                .read();
+            let remaining_liq_stashed = match starting_liq.is_zero() {
+                true => 0,
+                false => (remaining_liq * starting_liq_queued) / starting_liq
+            };
+            let remaining_liq_not_stashed = remaining_liq - remaining_liq_stashed;
+
+            // @dev All of the remaining liquidity becomes unlocked, any stashed liquidity is
+            // set aside and no longer participates in the protocol
+            self.vault_locked_balance.write(0);
+            self
+                .vault_stashed_balance
+                .write(self.vault_stashed_balance.read() + remaining_liq_stashed);
+            self
+                .vault_unlocked_balance
+                .write(self.vault_unlocked_balance.read() + remaining_liq_not_stashed);
+
+            // @dev Transfer payout from the vault to the just settled round,
+            if (total_payout > 0) {
+                self.get_eth_dispatcher().transfer(current_round.contract_address, total_payout);
+            }
+
+            // @dev Emit event
+            self.emit(Event::OptionRoundSettled(OptionRoundSettled {
+                round_id: current_round_id,
+                round_address: current_round.contract_address,
+                settlement_price: twap,
+                payout_per_option
+            }));
+
+            // @dev Deploy the next option round contract & update the current round id
+            self.deploy_next_round(L1Data { twap, volatility, reserve_price });
+
+            // @dev Return just the total payout
+            total_payout
         }
 
         /// Fossil

--- a/src/vault/interface.cairo
+++ b/src/vault/interface.cairo
@@ -1,7 +1,7 @@
 use starknet::{ContractAddress, ClassHash};
 use pitch_lake::option_round::interface::OptionRoundState;
 use pitch_lake::types::Bid;
-use pitch_lake::fossil_client::interface::{JobRequest, L1Data};
+use pitch_lake::fossil_client::interface::{JobRequest, L1Data, FossilCallbackReturn};
 
 // @dev An enum for each type of Vault
 #[derive(starknet::Store, Copy, Drop, Serde, PartialEq)]
@@ -126,7 +126,7 @@ trait IVault<TContractState> {
 
     /// State transitions
 
-    fn fossil_client_callback(ref self: TContractState, l1_data: L1Data, timestamp: u64);
+    fn fossil_client_callback(ref self: TContractState, l1_data: L1Data, timestamp: u64) -> FossilCallbackReturn;
 
     // @dev Start the current round's auction
     // @return The total options available in the auction
@@ -138,7 +138,7 @@ trait IVault<TContractState> {
 
     // @dev Settle the current round
     // @return The total payout for the round
-    fn settle_round(ref self: TContractState) -> u256;
+    // fn settle_round(ref self: TContractState, l1_data: L1Data) -> u256;
 
     // User actions
 


### PR DESCRIPTION
# Changes Summary

These changes consolidate the settlement process into the fossil callback, removing the need for a separate settlement step and ensuring atomic updates of L1 data and round settlement.

## Core Changes
- Modified `fossil_callback` in `FossilClient` to return a `FossilCallbackReturn` enum instead of void
- Removed separate `settle_round` function from Vault contract - settlement now happens directly in `fossil_client_callback`
- Added new return types:
  - `FossilCallbackReturn` enum with variants:
    - `RoundSettled(RoundSettledReturn)`
    - `FirstRoundInitialized`
  - `RoundSettledReturn` struct containing `total_payout`

## Contract Changes
### Vault Contract
- Modified `fossil_client_callback` to:
  - Handle settlement directly
  - Return the appropriate `FossilCallbackReturn` variant
  - Not store L1 pricing data anymore
  - Trigger settlement in same transaction

### FossilClient Contract
- Updated interface to include return type
- Modified callback implementation to propagate return value from vault

## Test Changes
- Removed `timeskip_and_settle_round` helper as settlement now happens in callback
- Removed `settle_option_round` and related methods from VaultFacade
- Updated test assertions to handle new return values
- Extracted helper methods from FossilClientFacade into a separate file -> `fossil_client_helpers.cairo`
- Modified test cases to work with combined callback/settlement flow
