### PR TITLE
Feat/recover with fossil

### DIFF
--- a/Scarb.lock
+++ b/Scarb.lock
@@ -2,6 +2,22 @@
 version = 1
 
 [[package]]
+name = "fp"
+version = "0.1.4"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:f636c02dfcb0fd321cd865c3ef0d5d352c7e27e4e21a2c3ad5836ab0d2511236"
+
+[[package]]
+name = "openzeppelin_access"
+version = "0.18.0"
+source = "registry+https://scarbs.xyz/"
+checksum = "sha256:424314072ae27d5b6f4264472a5c403711448ea62763a661b89e6ff5f23297fd"
+dependencies = [
+ "openzeppelin_introspection",
+ "openzeppelin_utils",
+]
+
+[[package]]
 name = "openzeppelin_account"
 version = "0.18.0"
 source = "registry+https://scarbs.xyz/"
@@ -38,6 +54,8 @@ checksum = "sha256:725b212839f3eddc32791408609099c5e808c167ca0cf331d8c1d778b07a4
 name = "pitch_lake"
 version = "0.1.0"
 dependencies = [
+ "fp",
+ "openzeppelin_access",
  "openzeppelin_token",
  "openzeppelin_utils",
 ]

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -11,6 +11,8 @@ casm = true
 starknet = "2.8.4"
 openzeppelin_token = "0.18.0"
 openzeppelin_utils = "0.18.0"
+openzeppelin_access = "0.18.0"
+fp = "0.1.4"
 #snforge_std = "0.31.0"
 
 [dev-dependencies]

--- a/src/fossil_client/contract.cairo
+++ b/src/fossil_client/contract.cairo
@@ -62,18 +62,18 @@ mod FossilClient {
     #[abi(embed_v0)]
     impl FossilClientImpl of IFossilClient<ContractState> {
         fn fossil_callback(
-            ref self: ContractState, mut request: Span<felt252>, mut result: Span<felt252>
+            ref self: ContractState, mut job_request: Span<felt252>, mut result: Span<felt252>
         ) {
-            // Deserialize request & result
+            // Deserialize job_request & result
             let JobRequest { vault_address, timestamp, program_id } = Serde::deserialize(
-                ref request
+                ref job_request
             )
                 .expect(Errors::FailedToDeserializeRequest);
 
             let FossilResult { l1_data, proof: _ } = Serde::deserialize(ref result)
                 .expect(Errors::FailedToDeserializeResult);
 
-            // Validate the request
+            // Validate the job_request
             assert(program_id == PROGRAM_ID, Errors::InvalidRequest);
             assert(timestamp.is_non_zero(), Errors::InvalidRequest);
 

--- a/src/fossil_client/contract.cairo
+++ b/src/fossil_client/contract.cairo
@@ -27,6 +27,7 @@ mod FossilClient {
     #[storage]
     struct Storage {
         verifier: ContractAddress,
+        is_verifier_set: bool,
         #[substorage(v0)]
         ownable: OwnableComponent::Storage,
     }
@@ -36,6 +37,7 @@ mod FossilClient {
     // *************************************************************************
 
     mod Errors {
+        const VerifierAlreadySet: felt252 = 'Verifier already set';
         const CallerNotVerifier: felt252 = 'Caller not the verifier';
         const FailedToDeserializeRequest: felt252 = 'Failed to deserialize request';
         const FailedToDeserializeResult: felt252 = 'Failed to deserialize result';
@@ -76,9 +78,19 @@ mod FossilClient {
 
     #[abi(embed_v0)]
     impl FossilClientImpl of IFossilClient<ContractState> {
+        fn get_verifier(self: @ContractState) -> ContractAddress {
+            self.verifier.read()
+        }
+
+        fn is_verifier_set(self: @ContractState) -> bool {
+            self.is_verifier_set.read()
+        }
+
         fn initialize_verifier(ref self: ContractState, verifier: ContractAddress) {
+            assert(!self.is_verifier_set.read(), Errors::VerifierAlreadySet);
             self.ownable.assert_only_owner();
             self.verifier.write(verifier);
+            self.is_verifier_set.write(true);
         }
 
         fn fossil_callback(

--- a/src/fossil_client/interface.cairo
+++ b/src/fossil_client/interface.cairo
@@ -6,6 +6,10 @@ use starknet::{ContractAddress, StorePacking};
 
 #[starknet::interface]
 trait IFossilClient<TContractState> {
+    // Set the verifier address, can only be called once
+    fn initialize_verifier(ref self: TContractState, verifier: ContractAddress);
+
+    // Called by Pitchlake Verifier
     fn fossil_callback(ref self: TContractState, job_request: Span<felt252>, result: Span<felt252>);
 }
 
@@ -13,21 +17,39 @@ trait IFossilClient<TContractState> {
 //                            PITCH LAKE CLIENT
 // *************************************************************************
 
-#[derive(Copy, Drop)]
+// Job request sent to Fossil
+// vault_address: Which vault is the data for
+// timestamp: Upper bound timestamp of gas data used in data calculation
+// program_id: 'PITCH_LAKE_V1'
+#[derive(Copy, Drop, PartialEq)]
 struct JobRequest {
-    vault_address: ContractAddress, // Which vault is this request for
-    // The timestamp the results are for
+    vault_address: ContractAddress,
     timestamp: u64,
-    // 'PITCH_LAKE_V1' (or program hash when proving ?)
-    program_id: felt252, // 'PITCH_LAKE_V1'}
+    program_id: felt252,
 }
 
+// Fossil job results (args, data and tolerances)
+#[derive(Copy, Drop, PartialEq)]
+struct VerifierData {
+    pub start_timestamp: u64,
+    pub end_timestamp: u64,
+    pub reserve_price: felt252,
+    pub floating_point_tolerance: felt252,
+    pub reserve_price_tolerance: felt252,
+    pub twap_tolerance: felt252,
+    pub gradient_tolerance: felt252,
+    pub twap_result: felt252,
+    pub max_return: felt252,
+}
+
+// JobRequest <-> Array<felt252>
 impl SerdeJobRequest of Serde<JobRequest> {
     fn serialize(self: @JobRequest, ref output: Array<felt252>) {
         self.vault_address.serialize(ref output);
         self.timestamp.serialize(ref output);
         self.program_id.serialize(ref output);
     }
+
     fn deserialize(ref serialized: Span<felt252>) -> Option<JobRequest> {
         let vault_address: ContractAddress = (*serialized.at(0))
             .try_into()
@@ -40,6 +62,53 @@ impl SerdeJobRequest of Serde<JobRequest> {
     }
 }
 
+// VerifierData <-> Array<felt252>
+impl SerdeVerifierData of Serde<VerifierData> {
+    fn serialize(self: @VerifierData, ref output: Array<felt252>) {
+        self.start_timestamp.serialize(ref output);
+        self.end_timestamp.serialize(ref output);
+        self.reserve_price.serialize(ref output);
+        self.floating_point_tolerance.serialize(ref output);
+        self.reserve_price_tolerance.serialize(ref output);
+        self.twap_tolerance.serialize(ref output);
+        self.gradient_tolerance.serialize(ref output);
+        self.twap_result.serialize(ref output);
+        self.max_return.serialize(ref output);
+    }
+
+    fn deserialize(ref serialized: Span<felt252>) -> Option<VerifierData> {
+        let start_timestamp: u64 = (*serialized.at(0))
+            .try_into()
+            .expect('failed to deser. start timestmp');
+        let end_timestamp: u64 = (*serialized.at(1))
+            .try_into()
+            .expect('failed to deser. end timestamp');
+        let reserve_price: felt252 = *serialized.at(2);
+        let floating_point_tolerance: felt252 = *serialized.at(3);
+        let reserve_price_tolerance: felt252 = *serialized.at(4);
+        let twap_tolerance: felt252 = *serialized.at(5);
+        let gradient_tolerance: felt252 = *serialized.at(6);
+        let twap_result: felt252 = *serialized.at(7);
+        let max_return: felt252 = *serialized.at(8);
+
+        Option::Some(
+            VerifierData {
+                start_timestamp,
+                end_timestamp,
+                reserve_price,
+                floating_point_tolerance,
+                reserve_price_tolerance,
+                twap_tolerance,
+                gradient_tolerance,
+                twap_result,
+                max_return
+            }
+        )
+    }
+}
+
+/// Old
+
 #[derive(Copy, Drop)]
 struct FossilResult {
     // TWAP, volatility, reserve price
@@ -48,6 +117,7 @@ struct FossilResult {
     proof: Span<felt252>,
 }
 
+// Fix this as per fossilmonorepo
 impl SerdeFossilResult of Serde<FossilResult> {
     fn serialize(self: @FossilResult, ref output: Array<felt252>) {
         self.l1_data.serialize(ref output);
@@ -56,9 +126,9 @@ impl SerdeFossilResult of Serde<FossilResult> {
     fn deserialize(ref serialized: Span<felt252>) -> Option<FossilResult> {
         let twap_low: u128 = (*serialized.at(0)).try_into().expect('failed deserialize twap');
         let twap_high: u128 = (*serialized.at(1)).try_into().expect('failed deserialize twap');
-        let volatility: u128 = (*serialized.at(2))
+        let max_return: u128 = (*serialized.at(2))
             .try_into()
-            .expect('failed deserialize volatility');
+            .expect('failed deserialize max_return');
         let reserve_price_low: u128 = (*serialized.at(3))
             .try_into()
             .expect('failed deserialize reserve');
@@ -70,7 +140,7 @@ impl SerdeFossilResult of Serde<FossilResult> {
             FossilResult {
                 l1_data: L1Data {
                     twap: u256 { low: twap_low, high: twap_high },
-                    volatility,
+                    max_return,
                     reserve_price: u256 { low: reserve_price_low, high: reserve_price_high }
                 },
                 proof
@@ -82,7 +152,7 @@ impl SerdeFossilResult of Serde<FossilResult> {
 #[derive(Default, Copy, Drop, Serde, PartialEq, starknet::Store)]
 struct L1Data {
     twap: u256,
-    volatility: u128,
+    max_return: u128,
     reserve_price: u256,
 }
 

--- a/src/fossil_client/interface.cairo
+++ b/src/fossil_client/interface.cairo
@@ -11,6 +11,12 @@ trait IFossilClient<TContractState> {
 
     // Called by Pitchlake Verifier
     fn fossil_callback(ref self: TContractState, job_request: Span<felt252>, result: Span<felt252>);
+
+    // Get the verifier address
+    fn get_verifier(self: @TContractState) -> ContractAddress;
+
+    // Get if the verifier has been set
+    fn is_verifier_set(self: @TContractState) -> bool;
 }
 
 // *************************************************************************

--- a/src/fossil_client/interface.cairo
+++ b/src/fossil_client/interface.cairo
@@ -6,7 +6,7 @@ use starknet::{ContractAddress, StorePacking};
 
 #[starknet::interface]
 trait IFossilClient<TContractState> {
-    fn fossil_callback(ref self: TContractState, request: Span<felt252>, result: Span<felt252>);
+    fn fossil_callback(ref self: TContractState, job_request: Span<felt252>, result: Span<felt252>);
 }
 
 // *************************************************************************

--- a/src/library/pricing_utils.cairo
+++ b/src/library/pricing_utils.cairo
@@ -36,7 +36,7 @@ fn calculate_total_options_available(
     }
 }
 
-// @note TODO
+// @note TODO: switch to using max_return and possibly floating points
 // cl = λ − k / (α × (k + 1))
 fn calculate_cap_level(a: u128, k: i128, vol: u128) -> u128 {
     // @dev λ = 2.3300 * vol

--- a/src/tests.cairo
+++ b/src/tests.cairo
@@ -1,4 +1,9 @@
 #[cfg(test)]
+mod fossil_client {
+    mod fossil_client_tests;
+}
+
+#[cfg(test)]
 mod vault {
     mod state_transition {
         mod auction_end_tests;

--- a/src/tests/fossil_client/fossil_client_tests.cairo
+++ b/src/tests/fossil_client/fossil_client_tests.cairo
@@ -1,0 +1,70 @@
+use pitch_lake::fossil_client::interface::{JobRequest, VerifierData};
+
+#[test]
+fn test_job_request_serialization() {
+    let job = JobRequest {
+        vault_address: 0xbeef.try_into().unwrap(), timestamp: 1234, program_id: 'PITCH_LAKE_V1',
+    };
+    let mut job_as_span = array![0xbeef, 1234, 'PITCH_LAKE_V1'].span();
+
+    // Test serialize
+    let mut serialized: Array<felt252> = array![];
+    job.serialize(ref serialized);
+    assert_eq!(serialized.span(), job_as_span);
+}
+
+#[test]
+fn test_job_request_deserialization() {
+    let job = JobRequest {
+        vault_address: 0xbeef.try_into().unwrap(), timestamp: 1234, program_id: 'PITCH_LAKE_V1',
+    };
+    let mut job_as_span = array![0xbeef, 1234, 'PITCH_LAKE_V1'].span();
+
+    // Test deserialize
+    let deserialized: JobRequest = Serde::deserialize(ref job_as_span)
+        .expect('failed to deser job request');
+    assert(job == deserialized, 'deserialized does not match');
+}
+
+#[test]
+fn test_verifier_serialization() {
+    let verifier_data = VerifierData {
+        start_timestamp: 1000,
+        end_timestamp: 2000,
+        reserve_price: 3000,
+        floating_point_tolerance: 10,
+        reserve_price_tolerance: 20,
+        twap_tolerance: 30,
+        gradient_tolerance: 40,
+        twap_result: 5000,
+        max_return: 6000
+    };
+    let mut serialized_span = array![1000, 2000, 3000, 10, 20, 30, 40, 5000, 6000].span();
+
+    // Test serialize
+    let mut serialized: Array<felt252> = array![];
+    verifier_data.serialize(ref serialized);
+    assert_eq!(serialized.span(), serialized_span);
+}
+
+#[test]
+fn test_verifier_deserialization() {
+    let verifier_data = VerifierData {
+        start_timestamp: 1000,
+        end_timestamp: 2000,
+        reserve_price: 3000,
+        floating_point_tolerance: 10,
+        reserve_price_tolerance: 20,
+        twap_tolerance: 30,
+        gradient_tolerance: 40,
+        twap_result: 5000,
+        max_return: 6000
+    };
+    let mut serialized_span = array![1000, 2000, 3000, 10, 20, 30, 40, 5000, 6000].span();
+
+    // Test deserialize
+    let deserialized: VerifierData = Serde::deserialize(ref serialized_span)
+        .expect('failed to deser verifier data');
+    assert(verifier_data == deserialized, 'deserialized does not match');
+}
+

--- a/src/tests/utils/facades/fossil_client_facade.cairo
+++ b/src/tests/utils/facades/fossil_client_facade.cairo
@@ -2,8 +2,11 @@ use crate::fossil_client::interface::{
     IFossilClientDispatcher, IFossilClientSafeDispatcher, IFossilClientDispatcherTrait,
     IFossilClientSafeDispatcherTrait
 };
-use crate::tests::utils::helpers::setup::FOSSIL_PROCESSOR;
+use crate::tests::utils::helpers::setup::{
+    FOSSIL_PROCESSOR, FOSSIL_CLIENT_OWNER, PITCHLAKE_VERIFIER
+};
 use starknet::testing::set_contract_address;
+use openzeppelin_access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};
 // add this and tests
 
 // test only fossil processor can call the client (fossil_callback)
@@ -26,10 +29,28 @@ impl FossilClientFacadeImpl of FossilClientFacadeTrait {
         IFossilClientSafeDispatcher { contract_address: self.contract_address }
     }
 
+    /// Getters
+    fn get_verifier(self: FossilClientFacade) -> starknet::ContractAddress {
+        self.dispatcher().get_verifier()
+    }
+
+    fn is_verifier_set(self: FossilClientFacade) -> bool {
+        self.dispatcher().is_verifier_set()
+    }
+
+    fn owner(self: FossilClientFacade) -> starknet::ContractAddress {
+        IOwnableDispatcher { contract_address: self.contract_address }.owner()
+    }
+
     /// Entrypoints
     fn fossil_callback(self: FossilClientFacade, request: Span<felt252>, result: Span<felt252>) {
-        set_contract_address(FOSSIL_PROCESSOR());
+        set_contract_address(self.owner());
         self.dispatcher().fossil_callback(request, result);
+    }
+
+    fn initialize_verifier(self: FossilClientFacade, verifier: starknet::ContractAddress) {
+        set_contract_address(FOSSIL_CLIENT_OWNER());
+        self.dispatcher().initialize_verifier(verifier);
     }
 
     #[feature("safe_dispatcher")]
@@ -38,6 +59,14 @@ impl FossilClientFacadeImpl of FossilClientFacadeTrait {
     ) {
         let safe = self.safe_dispatcher();
         safe.fossil_callback(request, result).expect_err(error);
+    }
+
+    #[feature("safe_dispatcher")]
+    fn initialize_verifier_expect_error(
+        self: FossilClientFacade, verifier: starknet::ContractAddress, error: felt252
+    ) {
+        let safe = self.safe_dispatcher();
+        safe.initialize_verifier(verifier).expect_err(error);
     }
 }
 

--- a/src/tests/utils/helpers/accelerators.cairo
+++ b/src/tests/utils/helpers/accelerators.cairo
@@ -93,8 +93,8 @@ fn accelerate_to_settled_custom(ref self: VaultFacade, l1_data: L1Data) -> u256 
 
     // Create a mock result (proofs do not matter)
     let mut result_serialized = array![];
-    let L1Data { twap, volatility, reserve_price } = l1_data;
-    FossilResult { l1_data: L1Data { twap, volatility, reserve_price }, proof: array![].span() }
+    let L1Data { twap, max_return, reserve_price } = l1_data;
+    FossilResult { l1_data: L1Data { twap, max_return, reserve_price }, proof: array![].span() }
         .serialize(ref result_serialized);
 
     // Make callback to fulfill the request
@@ -110,7 +110,7 @@ fn accelerate_to_settled_custom(ref self: VaultFacade, l1_data: L1Data) -> u256 
 // Settle the option round with a custom settlement price (compared to strike to determine payout)
 fn accelerate_to_settled(ref self: VaultFacade, twap: u256) -> u256 {
     accelerate_to_settled_custom(
-        ref self, L1Data { twap, volatility: 5000, reserve_price: to_gwei(2) }
+        ref self, L1Data { twap, max_return: 5000, reserve_price: to_gwei(2) }
     )
     //    // Get the data request to fulfill
 //    let mut request_serialized = array![];
@@ -119,7 +119,7 @@ fn accelerate_to_settled(ref self: VaultFacade, twap: u256) -> u256 {
 //    // Create a mock result (proofs do not matter)
 //    let mut result_serialized = array![];
 //    FossilResult {
-//        l1_data: L1Data { twap, volatility: 5000, reserve_price: to_gwei(2) },
+//        l1_data: L1Data { twap, max_return: 5000, reserve_price: to_gwei(2) },
 //        proof: array![].span()
 //    }
 //        .serialize(ref result_serialized);

--- a/src/tests/utils/helpers/setup.cairo
+++ b/src/tests/utils/helpers/setup.cairo
@@ -167,7 +167,7 @@ fn setup_facade_custom(alpha: u128, strike_level: i128) -> VaultFacade {
     let mut serialized_result = array![];
     vault_facade.get_request_to_start_first_round().serialize(ref serialized_request);
     FossilResult {
-        l1_data: L1Data { twap: to_gwei(10), volatility: 5000, reserve_price: to_gwei(2), },
+        l1_data: L1Data { twap: to_gwei(10), max_return: 5000, reserve_price: to_gwei(2), },
         proof: array!['doesnt', 'matter'].span()
     }
         .serialize(ref serialized_result);

--- a/src/tests/utils/helpers/setup.cairo
+++ b/src/tests/utils/helpers/setup.cairo
@@ -59,6 +59,15 @@ fn FOSSIL_PROCESSOR() -> ContractAddress {
     contract_address_const::<'FOSSIL PROCESSOR'>()
 }
 
+fn FOSSIL_CLIENT_OWNER() -> ContractAddress {
+    contract_address_const::<'FOSSIL CLIENT OWNER'>()
+}
+
+fn PITCHLAKE_VERIFIER() -> ContractAddress {
+    contract_address_const::<'FOSSIL PROCESSOR'>()
+}
+
+
 // Deploy eth contract for testing
 fn deploy_eth() -> ERC20ABIDispatcher {
     let mut calldata = array![];
@@ -81,16 +90,21 @@ fn deploy_eth() -> ERC20ABIDispatcher {
 
 fn deploy_fossil_client() -> FossilClientFacade {
     let mut calldata = array![];
-    calldata.append_serde(FOSSIL_PROCESSOR());
+    calldata.append_serde(FOSSIL_CLIENT_OWNER());
     let (contract_address, _): (ContractAddress, Span<felt252>) = deploy_syscall(
         FossilClient::TEST_CLASS_HASH.try_into().unwrap(), 'some salt', calldata.span(), false
     )
         .expect('DEPLOY_FOSSIL_CLIENT_FAILED');
 
+    let facade = FossilClientFacade { contract_address };
+
+    // Initialize verifier
+    facade.initialize_verifier(PITCHLAKE_VERIFIER());
+
     // Clear the event log (not needed)
     clear_event_logs(array![contract_address]);
 
-    return FossilClientFacade { contract_address };
+    facade
 }
 
 const ROUND_TRANSITION_DURATION: u64 = 3 * MINUTE;

--- a/src/tests/utils/helpers/setup.cairo
+++ b/src/tests/utils/helpers/setup.cairo
@@ -93,9 +93,9 @@ fn deploy_fossil_client() -> FossilClientFacade {
     return FossilClientFacade { contract_address };
 }
 
-const ROUND_TRANSITION_DURATION: u64= 3 * MINUTE;
-const AUCTION_DURATION: u64= 3 * MINUTE;
-const ROUND_DURATION: u64= 3 * MINUTE;
+const ROUND_TRANSITION_DURATION: u64 = 3 * MINUTE;
+const AUCTION_DURATION: u64 = 3 * MINUTE;
+const ROUND_DURATION: u64 = 3 * MINUTE;
 
 
 // Deploy the vault and fossil client

--- a/src/vault/contract.cairo
+++ b/src/vault/contract.cairo
@@ -596,7 +596,7 @@ mod Vault {
             );
 
             // @dev Assert the L1 data is valid
-            let L1Data { twap, volatility: _, reserve_price } = l1_data;
+            let L1Data { twap, max_return: _, reserve_price } = l1_data;
             assert(twap.is_non_zero() && reserve_price.is_non_zero(), Errors::InvalidL1Data);
 
             // @dev Requests can only be fulfilled if the current round is Running, or if the
@@ -681,7 +681,7 @@ mod Vault {
         fn settle_round(ref self: ContractState) -> u256 {
             // @dev Get pricing data set for the current round's settlement
             let current_round_id = self.current_round_id.read();
-            let L1Data { twap, volatility, reserve_price } = self
+            let L1Data { twap, max_return, reserve_price } = self
                 .l1_data
                 .entry(current_round_id)
                 .read();
@@ -729,7 +729,7 @@ mod Vault {
             }
 
             // @dev Deploy the next option round contract & update the current round id
-            self.deploy_next_round(L1Data { twap, volatility, reserve_price });
+            self.deploy_next_round(L1Data { twap, max_return, reserve_price });
 
             // @dev Return the total payout of the settled round
             total_payout
@@ -845,12 +845,12 @@ mod Vault {
                 return PricingData { strike_price: 0, cap_level: 0, reserve_price: 0 };
             }
 
-            let L1Data { twap, volatility, reserve_price } = l1_data;
+            let L1Data { twap, max_return, reserve_price } = l1_data;
 
             let alpha = self.alpha.read();
             let k = self.strike_level.read();
 
-            let cap_level = calculate_cap_level(alpha, k, volatility);
+            let cap_level = calculate_cap_level(alpha, k, max_return);
             let strike_price = calculate_strike_price(k, twap);
 
             PricingData { strike_price, cap_level, reserve_price }

--- a/src/vault/interface.cairo
+++ b/src/vault/interface.cairo
@@ -14,7 +14,7 @@ enum VaultType {
 // @dev Constructor arguments
 #[derive(Drop, Serde)]
 struct ConstructorArgs {
-    fossil_client_address: ContractAddress,
+    verifier_address: ContractAddress,
     eth_address: ContractAddress,
     option_round_class_hash: ClassHash,
     alpha: u128,
@@ -42,7 +42,7 @@ trait IVault<TContractState> {
     fn get_eth_address(self: @TContractState) -> ContractAddress;
 
     // @dev The the Fossil Client's address
-    fn get_fossil_client_address(self: @TContractState) -> ContractAddress;
+    fn get_verifier_address(self: @TContractState) -> ContractAddress;
 
     // @dev The number of seconds between a round deploying and its auction starting
     fn get_round_transition_duration(self: @TContractState) -> u64;
@@ -126,7 +126,10 @@ trait IVault<TContractState> {
 
     /// State transitions
 
-    fn fossil_client_callback(ref self: TContractState, l1_data: L1Data, timestamp: u64);
+    // @dev Set L1 data to settle the current round and start the next round
+    // @dev Called by Pitchlake Verifier
+    // @dev Used to initialize the first round and settle all subsequent rounds
+    fn fossil_callback(ref self: TContractState, job_request: Span<felt252>, result: Span<felt252>);
 
     // @dev Start the current round's auction
     // @return The total options available in the auction


### PR DESCRIPTION
# Purpose:

- Move `fossil_callback` entry point to Vault
- Update cap level calculation to use max_return

# Current Progress:

- `fossil_callback` added to IVault
- `fossil_callback` started in Vault

# Next Steps:

- Make `fossil_callback` settle the current round (move logic from `settle_round`) (if current round == Running)
- Remove `settle_round`
- Fix tests