### PR TITLE
Update journal struct and serde impl

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-scarb 2.8.4
-starknet-foundry 0.32.0
+scarb 2.12.1
+starknet-foundry 0.49.0
 dojo 1.0.0-alpha.17

--- a/Scarb.lock
+++ b/Scarb.lock
@@ -9,19 +9,18 @@ checksum = "sha256:f636c02dfcb0fd321cd865c3ef0d5d352c7e27e4e21a2c3ad5836ab0d2511
 
 [[package]]
 name = "openzeppelin_access"
-version = "0.18.0"
+version = "2.0.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:424314072ae27d5b6f4264472a5c403711448ea62763a661b89e6ff5f23297fd"
+checksum = "sha256:511681dd26d814ee2bc996d44ff8cb4aaa5ae9d14272130def7eb901cf004850"
 dependencies = [
  "openzeppelin_introspection",
- "openzeppelin_utils",
 ]
 
 [[package]]
 name = "openzeppelin_account"
-version = "0.18.0"
+version = "2.0.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:83e6571cac4c67049c8d0ab4e3c7ad146d582d7605e7354248835833e1d26c4a"
+checksum = "sha256:fb3381c50d68b028d3801feb43df378e2bd62137b6884844f8f60aefe796188b"
 dependencies = [
  "openzeppelin_introspection",
  "openzeppelin_utils",
@@ -29,16 +28,17 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin_introspection"
-version = "0.18.0"
+version = "2.0.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:46c4cc6c95c9baa4c7d5cc0ed2bdaf334f46c25a8c92b3012829fff936e3042b"
+checksum = "sha256:87773ed6cd2318f169283ecbbb161890d1996260a80302d81ec45b70ee5e54c1"
 
 [[package]]
 name = "openzeppelin_token"
-version = "0.18.0"
+version = "2.0.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:eafbe13f6a0487ce212459e25a81ae07f340ba76208ad4616626eb2d25a9625e"
+checksum = "sha256:6fe61f63b5a6706018265fb7373b6e5bd3ff829bdc760b2b90296b1e708d180c"
 dependencies = [
+ "openzeppelin_access",
  "openzeppelin_account",
  "openzeppelin_introspection",
  "openzeppelin_utils",
@@ -46,9 +46,9 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin_utils"
-version = "0.18.0"
+version = "2.0.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:725b212839f3eddc32791408609099c5e808c167ca0cf331d8c1d778b07a4e21"
+checksum = "sha256:bf799c794139837f397975ffdf6a7ed5032d198bbf70e87a8f44f144a9dfc505"
 
 [[package]]
 name = "pitch_lake"

--- a/Scarb.toml
+++ b/Scarb.toml
@@ -2,19 +2,25 @@
 name = "pitch_lake"
 description = "Oiler PitchLake"
 version = "0.1.0"
+edition = "2023_11"
 
 [[target.starknet-contract]]
 sierra = true
 casm = true
 
 [dependencies]
-starknet = "2.8.4"
-openzeppelin_token = "0.18.0"
-openzeppelin_utils = "0.18.0"
-openzeppelin_access = "0.18.0"
+starknet = "2.12.1"
+openzeppelin_token = "2.0.0"
+openzeppelin_utils = "2.0.0"
+openzeppelin_access = "2.0.0"
 fp = "0.1.4"
 #snforge_std = "0.31.0"
 
 [dev-dependencies]
-cairo_test = "2.8.4"
+cairo_test = "2.12.1"
 #snforge_std = "0.32.0"
+
+[tool.fmt]
+sort-module-level-items = true
+
+[lib]

--- a/argent/src/account/interface.cairo
+++ b/argent/src/account/interface.cairo
@@ -1,5 +1,5 @@
-use argent::recovery::interface::{LegacyEscape, EscapeStatus};
-use argent::signer::signer_signature::{Signer, SignerType, SignerSignature};
+use argent::recovery::interface::{EscapeStatus, LegacyEscape};
+use argent::signer::signer_signature::{Signer, SignerSignature, SignerType};
 use starknet::account::Call;
 
 const SRC5_ACCOUNT_INTERFACE_ID: felt252 =
@@ -28,7 +28,7 @@ trait IAccount<TContractState> {
     /// @return The shortstring 'VALID' when the signature is valid, 0 if the signature doesn't
     /// match the hash @dev it can also panic if the signature is not in a valid format
     fn is_valid_signature(
-        self: @TContractState, hash: felt252, signature: Array<felt252>
+        self: @TContractState, hash: felt252, signature: Array<felt252>,
     ) -> felt252;
 }
 
@@ -40,7 +40,7 @@ trait IArgentAccount<TContractState> {
         class_hash: felt252,
         contract_address_salt: felt252,
         threshold: usize,
-        signers: Array<Signer>
+        signers: Array<Signer>,
     ) -> felt252;
     fn get_name(self: @TContractState) -> felt252;
     fn get_version(self: @TContractState) -> Version;
@@ -54,7 +54,7 @@ trait IArgentUserAccount<TContractState> {
         class_hash: felt252,
         contract_address_salt: felt252,
         owner: Signer,
-        guardian: Option<Signer>
+        guardian: Option<Signer>,
     ) -> felt252;
 
     /// @notice Changes the security period used for escapes
@@ -164,6 +164,6 @@ trait IDeprecatedArgentAccount<TContractState> {
     /// For compatibility reasons this function returns 1 when the signature is valid, and panics
     /// otherwise
     fn isValidSignature(
-        self: @TContractState, hash: felt252, signatures: Array<felt252>
+        self: @TContractState, hash: felt252, signatures: Array<felt252>,
     ) -> felt252;
 }

--- a/argent/src/external_recovery/external_recovery.cairo
+++ b/argent/src/external_recovery/external_recovery.cairo
@@ -1,4 +1,4 @@
-use argent::external_recovery::interface::{EscapeCall, Escape};
+use argent::external_recovery::interface::{Escape, EscapeCall};
 use argent::recovery::interface::{EscapeEnabled, EscapeStatus};
 use argent::utils::serialization::serialize;
 
@@ -15,23 +15,20 @@ trait IExternalRecoveryCallback<TContractState> {
 #[starknet::component]
 mod external_recovery_component {
     use argent::external_recovery::interface::{
-        IExternalRecovery, EscapeCall, Escape, EscapeTriggered, EscapeExecuted, EscapeCanceled,
+        Escape, EscapeCall, EscapeCanceled, EscapeExecuted, EscapeTriggered, IExternalRecovery,
     };
     use argent::recovery::interface::{EscapeEnabled, EscapeStatus};
     use argent::signer::signer_signature::{Signer, SignerTrait};
     use argent::signer_storage::interface::ISignerList;
-    use argent::signer_storage::signer_list::{
-        signer_list_component, signer_list_component::{SignerListInternalImpl}
-    };
+    use argent::signer_storage::signer_list::signer_list_component;
+    use argent::signer_storage::signer_list::signer_list_component::SignerListInternalImpl;
     use argent::utils::asserts::assert_only_self;
     use argent::utils::serialization::serialize;
-    use openzeppelin::security::reentrancyguard::{
-        ReentrancyGuardComponent, ReentrancyGuardComponent::InternalImpl
-    };
-    use starknet::{
-        get_block_timestamp, get_contract_address, get_caller_address, ContractAddress,
-        account::Call, contract_address::contract_address_const
-    };
+    use openzeppelin::security::reentrancyguard::ReentrancyGuardComponent;
+    use openzeppelin::security::reentrancyguard::ReentrancyGuardComponent::InternalImpl;
+    use starknet::account::Call;
+    use starknet::contract_address::contract_address_const;
+    use starknet::{ContractAddress, get_block_timestamp, get_caller_address, get_contract_address};
     use super::{IExternalRecoveryCallback, get_escape_call_hash};
 
     /// Minimum time for the escape security period
@@ -41,7 +38,7 @@ mod external_recovery_component {
     struct Storage {
         escape_enabled: EscapeEnabled,
         escape: Escape,
-        guardian: ContractAddress
+        guardian: ContractAddress,
     }
 
     #[event]
@@ -58,7 +55,7 @@ mod external_recovery_component {
         +HasComponent<TContractState>,
         +IExternalRecoveryCallback<TContractState>,
         +Drop<TContractState>,
-        impl ReentrancyGuard: ReentrancyGuardComponent::HasComponent<TContractState>
+        impl ReentrancyGuard: ReentrancyGuardComponent::HasComponent<TContractState>,
     > of IExternalRecovery<ComponentState<TContractState>> {
         fn trigger_escape(ref self: ComponentState<TContractState>, call: EscapeCall) {
             self.assert_only_guardian();
@@ -71,7 +68,7 @@ mod external_recovery_component {
                     || call.selector == selector!("remove_signers")
                     || call.selector == selector!("add_signers")
                     || call.selector == selector!("change_threshold"),
-                'argent/invalid-selector'
+                'argent/invalid-selector',
             );
 
             let current_escape: Escape = self.escape.read();
@@ -99,7 +96,7 @@ mod external_recovery_component {
             assert(current_escape_status == EscapeStatus::Ready, 'argent/invalid-escape');
             assert(
                 current_escape.call_hash == get_escape_call_hash(@call),
-                'argent/invalid-escape-call'
+                'argent/invalid-escape-call',
             );
 
             let mut callback = self.get_contract_mut();
@@ -141,7 +138,7 @@ mod external_recovery_component {
             is_enabled: bool,
             security_period: u64,
             expiry_period: u64,
-            guardian: ContractAddress
+            guardian: ContractAddress,
         ) {
             assert_only_self();
             // cannot toggle escape if there is an ongoing escape
@@ -171,7 +168,7 @@ mod external_recovery_component {
                     security_period == 0
                         && expiry_period == 0
                         && guardian == contract_address_const::<0>(),
-                    'argent/invalid-escape-params'
+                    'argent/invalid-escape-params',
                 );
                 self
                     .escape_enabled
@@ -188,7 +185,7 @@ mod external_recovery_component {
     #[generate_trait]
     impl Private<TContractState, +HasComponent<TContractState>> of PrivateTrait<TContractState> {
         fn get_escape_status(
-            self: @ComponentState<TContractState>, escape_ready_at: u64, expiry_period: u64
+            self: @ComponentState<TContractState>, escape_ready_at: u64, expiry_period: u64,
         ) -> EscapeStatus {
             if escape_ready_at == 0 {
                 return EscapeStatus::None;

--- a/argent/src/external_recovery/interface.cairo
+++ b/argent/src/external_recovery/interface.cairo
@@ -7,14 +7,14 @@ use starknet::ContractAddress;
 #[derive(Drop, Serde, Copy, starknet::Store)]
 struct Escape {
     ready_at: u64,
-    call_hash: felt252
+    call_hash: felt252,
 }
 
 /// @notice The call to be performed once the escape is Ready
 #[derive(Drop, Serde)]
 struct EscapeCall {
     selector: felt252,
-    calldata: Array<felt252>
+    calldata: Array<felt252>,
 }
 
 #[starknet::interface]
@@ -25,7 +25,7 @@ trait IExternalRecovery<TContractState> {
         is_enabled: bool,
         security_period: u64,
         expiry_period: u64,
-        guardian: ContractAddress
+        guardian: ContractAddress,
     );
     fn get_guardian(self: @TContractState) -> ContractAddress;
     /// @notice Triggers the escape
@@ -57,14 +57,14 @@ struct EscapeTriggered {
 /// @param call_hash hash of the executed EscapeCall
 #[derive(Drop, starknet::Event)]
 struct EscapeExecuted {
-    call_hash: felt252
+    call_hash: felt252,
 }
 
 /// @notice Signer escape was canceled
 /// @param call_hash hash of EscapeCall
 #[derive(Drop, starknet::Event)]
 struct EscapeCanceled {
-    call_hash: felt252
+    call_hash: felt252,
 }
 
 impl DefaultEscape of Default<Escape> {

--- a/argent/src/introspection/src5.cairo
+++ b/argent/src/introspection/src5.cairo
@@ -1,12 +1,13 @@
 #[starknet::component]
 mod src5_component {
     use argent::account::interface::{
-        SRC5_ACCOUNT_INTERFACE_ID, SRC5_ACCOUNT_INTERFACE_ID_OLD_1, SRC5_ACCOUNT_INTERFACE_ID_OLD_2
+        SRC5_ACCOUNT_INTERFACE_ID, SRC5_ACCOUNT_INTERFACE_ID_OLD_1, SRC5_ACCOUNT_INTERFACE_ID_OLD_2,
     };
-    use argent::introspection::interface::{ISRC5, ISRC5Legacy};
-    use argent::introspection::interface::{SRC5_INTERFACE_ID, SRC5_INTERFACE_ID_OLD};
+    use argent::introspection::interface::{
+        ISRC5, ISRC5Legacy, SRC5_INTERFACE_ID, SRC5_INTERFACE_ID_OLD,
+    };
     use argent::outside_execution::interface::{
-        ERC165_OUTSIDE_EXECUTION_INTERFACE_ID_REV_0, ERC165_OUTSIDE_EXECUTION_INTERFACE_ID_REV_1
+        ERC165_OUTSIDE_EXECUTION_INTERFACE_ID_REV_0, ERC165_OUTSIDE_EXECUTION_INTERFACE_ID_REV_1,
     };
 
     #[storage]
@@ -14,10 +15,10 @@ mod src5_component {
 
     #[embeddable_as(SRC5Impl)]
     impl SRC5<
-        TContractState, +HasComponent<TContractState>
+        TContractState, +HasComponent<TContractState>,
     > of ISRC5<ComponentState<TContractState>> {
         fn supports_interface(
-            self: @ComponentState<TContractState>, interface_id: felt252
+            self: @ComponentState<TContractState>, interface_id: felt252,
         ) -> bool {
             if interface_id == SRC5_INTERFACE_ID {
                 true
@@ -41,10 +42,10 @@ mod src5_component {
 
     #[embeddable_as(SRC5LegacyImpl)]
     impl SRC5Legacy<
-        TContractState, +HasComponent<TContractState>
+        TContractState, +HasComponent<TContractState>,
     > of ISRC5Legacy<ComponentState<TContractState>> {
         fn supportsInterface(
-            self: @ComponentState<TContractState>, interfaceId: felt252
+            self: @ComponentState<TContractState>, interfaceId: felt252,
         ) -> felt252 {
             if self.supports_interface(interfaceId) {
                 1

--- a/argent/src/mocks/future_argent_multisig.cairo
+++ b/argent/src/mocks/future_argent_multisig.cairo
@@ -6,29 +6,26 @@
 #[starknet::contract(account)]
 mod MockFutureArgentMultisig {
     use argent::account::interface::{
-        IAccount, IArgentAccount, IArgentAccountDispatcher, IArgentAccountDispatcherTrait, Version
+        IAccount, IArgentAccount, IArgentAccountDispatcher, IArgentAccountDispatcherTrait, Version,
     };
     use argent::external_recovery::external_recovery::IExternalRecoveryCallback;
     use argent::introspection::src5::src5_component;
-    use argent::multisig::{multisig::multisig_component};
-
-    use argent::signer::{
-        signer_signature::{Signer, SignerTrait, SignerSignature, SignerSignatureTrait}
+    use argent::multisig::multisig::multisig_component;
+    use argent::signer::signer_signature::{
+        Signer, SignerSignature, SignerSignatureTrait, SignerTrait,
     };
-    use argent::signer_storage::{
-        interface::ISignerList,
-        signer_list::{signer_list_component, signer_list_component::SignerListInternalImpl}
-    };
-    use argent::upgrade::{
-        upgrade::upgrade_component, interface::{IUpgradableCallback, IUpgradableCallbackOld}
-    };
-    use argent::utils::{
-        asserts::{assert_no_self_call, assert_only_protocol, assert_only_self,},
-        calls::execute_multicall, serialization::full_deserialize,
-    };
+    use argent::signer_storage::interface::ISignerList;
+    use argent::signer_storage::signer_list::signer_list_component;
+    use argent::signer_storage::signer_list::signer_list_component::SignerListInternalImpl;
+    use argent::upgrade::interface::{IUpgradableCallback, IUpgradableCallbackOld};
+    use argent::upgrade::upgrade::upgrade_component;
+    use argent::utils::asserts::{assert_no_self_call, assert_only_protocol, assert_only_self};
+    use argent::utils::calls::execute_multicall;
+    use argent::utils::serialization::full_deserialize;
     use core::array::ArrayTrait;
     use core::result::ResultTrait;
-    use starknet::{get_tx_info, get_contract_address, VALIDATED, ClassHash, account::Call};
+    use starknet::account::Call;
+    use starknet::{ClassHash, VALIDATED, get_contract_address, get_tx_info};
 
     const NAME: felt252 = 'ArgentMultisig';
     const VERSION_MAJOR: u8 = 0;
@@ -96,14 +93,14 @@ mod MockFutureArgentMultisig {
         }
 
         fn is_valid_signature(
-            self: @ContractState, hash: felt252, signature: Array<felt252>
+            self: @ContractState, hash: felt252, signature: Array<felt252>,
         ) -> felt252 {
             if self
                 .multisig
                 .is_valid_signature_with_threshold(
                     hash: hash,
                     threshold: self.multisig.threshold.read(),
-                    signer_signatures: parse_signature_array(signature.span())
+                    signer_signatures: parse_signature_array(signature.span()),
                 ) {
                 VALIDATED
             } else {
@@ -123,7 +120,7 @@ mod MockFutureArgentMultisig {
             class_hash: felt252,
             contract_address_salt: felt252,
             threshold: usize,
-            signers: Array<Signer>
+            signers: Array<Signer>,
         ) -> felt252 {
             panic_with_felt252('argent/deploy-not-available')
         }
@@ -151,16 +148,16 @@ mod MockFutureArgentMultisig {
     impl UpgradeableCallbackImpl of IUpgradableCallback<ContractState> {
         // Called when coming from account 0.2.0+
         fn perform_upgrade(
-            ref self: ContractState, new_implementation: ClassHash, data: Span<felt252>
+            ref self: ContractState, new_implementation: ClassHash, data: Span<felt252>,
         ) {
             assert_only_self();
             let current_version = IArgentAccountDispatcher {
-                contract_address: get_contract_address()
+                contract_address: get_contract_address(),
             }
                 .get_version();
             assert(
                 current_version.major == 0 && current_version.minor == 2,
-                'argent/invalid-from-version'
+                'argent/invalid-from-version',
             );
             assert(data.len() == 0, 'argent/unexpected-data');
             self.upgrade.complete_upgrade(new_implementation);
@@ -171,14 +168,14 @@ mod MockFutureArgentMultisig {
     #[generate_trait]
     impl Private of PrivateTrait {
         fn assert_valid_signatures(
-            self: @ContractState, execution_hash: felt252, signature: Span<felt252>
+            self: @ContractState, execution_hash: felt252, signature: Span<felt252>,
         ) {
             let valid = self
                 .multisig
                 .is_valid_signature_with_threshold(
                     hash: execution_hash,
                     threshold: self.multisig.threshold.read(),
-                    signer_signatures: parse_signature_array(signature)
+                    signer_signatures: parse_signature_array(signature),
                 );
             assert(valid, 'argent/invalid-signature');
         }

--- a/argent/src/mocks/mock_dapp.cairo
+++ b/argent/src/mocks/mock_dapp.cairo
@@ -18,7 +18,7 @@ trait IMockDapp<TContractState> {
 
 #[starknet::contract]
 mod MockDapp {
-    use starknet::{get_caller_address, ContractAddress};
+    use starknet::{ContractAddress, get_caller_address};
 
     #[storage]
     struct Storage {

--- a/argent/src/mocks/mock_erc20.cairo
+++ b/argent/src/mocks/mock_erc20.cairo
@@ -10,10 +10,10 @@ trait IErc20Mock<TContractState> {
     fn mint(ref self: TContractState, to: ContractAddress, amount: u256);
     fn approve(ref self: TContractState, spender: ContractAddress, amount: u256);
     fn transfer_from(
-        ref self: TContractState, sender: ContractAddress, recipient: ContractAddress, amount: u256
+        ref self: TContractState, sender: ContractAddress, recipient: ContractAddress, amount: u256,
     ) -> bool;
     fn transferFrom(
-        ref self: TContractState, sender: ContractAddress, recipient: ContractAddress, amount: u256
+        ref self: TContractState, sender: ContractAddress, recipient: ContractAddress, amount: u256,
     ) -> bool;
     fn balance_of(self: @TContractState, account: ContractAddress) -> u256;
     fn allowance(self: @TContractState, owner: ContractAddress, spender: ContractAddress) -> u256;
@@ -21,7 +21,8 @@ trait IErc20Mock<TContractState> {
 
 #[starknet::contract]
 mod Erc20Mock {
-    use starknet::{info::{get_caller_address}, ContractAddress};
+    use starknet::ContractAddress;
+    use starknet::info::get_caller_address;
 
     #[storage]
     struct Storage {
@@ -39,7 +40,7 @@ mod Erc20Mock {
             ref self: ContractState,
             sender: ContractAddress,
             recipient: ContractAddress,
-            amount: u256
+            amount: u256,
         ) -> bool {
             self.transfer_from_internal(sender, recipient, amount)
         }
@@ -48,7 +49,7 @@ mod Erc20Mock {
             ref self: ContractState,
             sender: ContractAddress,
             recipient: ContractAddress,
-            amount: u256
+            amount: u256,
         ) -> bool {
             self.transfer_from_internal(sender, recipient, amount)
         }
@@ -63,7 +64,7 @@ mod Erc20Mock {
         }
 
         fn allowance(
-            self: @ContractState, owner: ContractAddress, spender: ContractAddress
+            self: @ContractState, owner: ContractAddress, spender: ContractAddress,
         ) -> u256 {
             self.allowances.read((owner, spender))
         }
@@ -74,7 +75,7 @@ mod Erc20Mock {
             ref self: ContractState,
             sender: ContractAddress,
             recipient: ContractAddress,
-            amount: u256
+            amount: u256,
         ) -> bool {
             let caller = get_caller_address();
             let current_allowance = self.allowances.read((sender, caller));

--- a/argent/src/mocks/recovery_mocks.cairo
+++ b/argent/src/mocks/recovery_mocks.cairo
@@ -6,7 +6,7 @@
 #[starknet::contract]
 mod ThresholdRecoveryMock {
     use argent::multisig::multisig::multisig_component;
-    use argent::recovery::{threshold_recovery::threshold_recovery_component};
+    use argent::recovery::threshold_recovery::threshold_recovery_component;
     use argent::signer_storage::signer_list::signer_list_component;
 
     component!(path: threshold_recovery_component, storage: escape, event: EscapeEvents);
@@ -51,8 +51,8 @@ mod ThresholdRecoveryMock {
 }
 #[starknet::contract]
 mod ExternalRecoveryMock {
-    use argent::external_recovery::{
-        external_recovery::{external_recovery_component, IExternalRecoveryCallback}
+    use argent::external_recovery::external_recovery::{
+        IExternalRecoveryCallback, external_recovery_component,
     };
     use argent::multisig::multisig::multisig_component;
     use argent::signer_storage::signer_list::signer_list_component;
@@ -73,7 +73,7 @@ mod ExternalRecoveryMock {
 
     // Reentrancy guard
     component!(
-        path: ReentrancyGuardComponent, storage: reentrancy_guard, event: ReentrancyGuardEvent
+        path: ReentrancyGuardComponent, storage: reentrancy_guard, event: ReentrancyGuardEvent,
     );
     impl ReentrancyGuardInternalImpl = ReentrancyGuardComponent::InternalImpl<ContractState>;
 
@@ -104,15 +104,15 @@ mod ExternalRecoveryMock {
 
     impl IExternalRecoveryCallbackImpl of IExternalRecoveryCallback<ContractState> {
         fn execute_recovery_call(
-            ref self: ContractState, selector: felt252, calldata: Span<felt252>
+            ref self: ContractState, selector: felt252, calldata: Span<felt252>,
         ) {
             execute_multicall(
                 array![
                     starknet::account::Call {
-                        to: starknet::get_contract_address(), selector, calldata
-                    }
+                        to: starknet::get_contract_address(), selector, calldata,
+                    },
                 ]
-                    .span()
+                    .span(),
             );
         }
     }

--- a/argent/src/mocks/signature_verifier.cairo
+++ b/argent/src/mocks/signature_verifier.cairo
@@ -1,7 +1,6 @@
 #[starknet::contract]
 mod SignatureVerifier {
-    use argent::signer::{signer_signature::{Signer, SignerSignature, SignerSignatureTrait,}};
-
+    use argent::signer::signer_signature::{Signer, SignerSignature, SignerSignatureTrait};
     use argent::utils::serialization::full_deserialize;
     use starknet::VALIDATED;
 

--- a/argent/src/multisig/interface.cairo
+++ b/argent/src/multisig/interface.cairo
@@ -1,5 +1,6 @@
 use argent::signer::signer_signature::{Signer, SignerSignature};
-use starknet::{ContractAddress, account::Call};
+use starknet::ContractAddress;
+use starknet::account::Call;
 
 #[starknet::interface]
 trait IArgentMultisig<TContractState> {
@@ -21,7 +22,7 @@ trait IArgentMultisig<TContractState> {
     /// @param new_threshold New threshold
     /// @param signers_to_remove All the signers to remove
     fn remove_signers(
-        ref self: TContractState, new_threshold: usize, signers_to_remove: Array<Signer>
+        ref self: TContractState, new_threshold: usize, signers_to_remove: Array<Signer>,
     );
 
     /// @notice Replace one signer with a different one
@@ -43,7 +44,7 @@ trait IArgentMultisig<TContractState> {
     /// @param hash Hash of the message being signed
     /// @param signer_signature Signature to be verified
     fn is_valid_signer_signature(
-        self: @TContractState, hash: felt252, signer_signature: SignerSignature
+        self: @TContractState, hash: felt252, signer_signature: SignerSignature,
     ) -> bool;
 }
 
@@ -51,13 +52,13 @@ trait IArgentMultisig<TContractState> {
 trait IArgentMultisigInternal<TContractState> {
     fn initialize(ref self: TContractState, threshold: usize, signers: Array<Signer>);
     fn assert_valid_threshold_and_signers_count(
-        self: @TContractState, threshold: usize, signers_len: usize
+        self: @TContractState, threshold: usize, signers_len: usize,
     );
     fn assert_valid_storage(self: @TContractState);
     fn is_valid_signature_with_threshold(
         self: @TContractState,
         hash: felt252,
         threshold: u32,
-        signer_signatures: Array<SignerSignature>
+        signer_signatures: Array<SignerSignature>,
     ) -> bool;
 }

--- a/argent/src/multisig/multisig.cairo
+++ b/argent/src/multisig/multisig.cairo
@@ -3,21 +3,16 @@
 #[starknet::component]
 mod multisig_component {
     use argent::multisig::interface::{IArgentMultisig, IArgentMultisigInternal};
-    use argent::signer::{
-        signer_signature::{
-            Signer, SignerTrait, SignerSignature, SignerSignatureTrait, SignerSpanTrait
-        },
+    use argent::signer::signer_signature::{
+        Signer, SignerSignature, SignerSignatureTrait, SignerSpanTrait, SignerTrait,
     };
-    use argent::signer_storage::{
-        interface::ISignerList,
-        signer_list::{
-            signer_list_component,
-            signer_list_component::{
-                OwnerAddedGuid, OwnerRemovedGuid, SignerLinked, SignerListInternalImpl
-            }
-        }
+    use argent::signer_storage::interface::ISignerList;
+    use argent::signer_storage::signer_list::signer_list_component;
+    use argent::signer_storage::signer_list::signer_list_component::{
+        OwnerAddedGuid, OwnerRemovedGuid, SignerLinked, SignerListInternalImpl,
     };
-    use argent::utils::{transaction_version::is_estimate_transaction, asserts::assert_only_self};
+    use argent::utils::asserts::assert_only_self;
+    use argent::utils::transaction_version::is_estimate_transaction;
 
     /// Too many owners could make the multisig unable to process transactions if we reach a limit
     const MAX_SIGNERS_COUNT: usize = 32;
@@ -30,7 +25,7 @@ mod multisig_component {
     #[event]
     #[derive(Drop, starknet::Event)]
     enum Event {
-        ThresholdUpdated: ThresholdUpdated
+        ThresholdUpdated: ThresholdUpdated,
     }
 
     /// @notice Emitted when the multisig threshold changes
@@ -45,7 +40,7 @@ mod multisig_component {
         TContractState,
         +HasComponent<TContractState>,
         impl SignerList: signer_list_component::HasComponent<TContractState>,
-        +Drop<TContractState>
+        +Drop<TContractState>,
     > of IArgentMultisig<ComponentState<TContractState>> {
         fn change_threshold(ref self: ComponentState<TContractState>, new_threshold: usize) {
             assert_only_self();
@@ -60,7 +55,7 @@ mod multisig_component {
         fn add_signers(
             ref self: ComponentState<TContractState>,
             new_threshold: usize,
-            signers_to_add: Array<Signer>
+            signers_to_add: Array<Signer>,
         ) {
             assert_only_self();
             let mut signer_list_comp = get_dep_component_mut!(ref self, SignerList);
@@ -78,7 +73,7 @@ mod multisig_component {
                 let signer_guid = guids.pop_front().unwrap();
                 signer_list_comp.emit(OwnerAddedGuid { new_owner_guid: signer_guid });
                 signer_list_comp.emit(SignerLinked { signer_guid, signer: *signer });
-            };
+            }
 
             self.threshold.write(new_threshold);
             if previous_threshold != new_threshold {
@@ -89,7 +84,7 @@ mod multisig_component {
         fn remove_signers(
             ref self: ComponentState<TContractState>,
             new_threshold: usize,
-            signers_to_remove: Array<Signer>
+            signers_to_remove: Array<Signer>,
         ) {
             assert_only_self();
             let mut signer_list_comp = get_dep_component_mut!(ref self, SignerList);
@@ -103,7 +98,7 @@ mod multisig_component {
             signer_list_comp.remove_signers(guids.span(), last_signer: last_signer_guid);
             while let Option::Some(removed_owner_guid) = guids.pop_front() {
                 signer_list_comp.emit(OwnerRemovedGuid { removed_owner_guid })
-            };
+            }
 
             self.threshold.write(new_threshold);
             if previous_threshold != new_threshold {
@@ -114,7 +109,7 @@ mod multisig_component {
         fn replace_signer(
             ref self: ComponentState<TContractState>,
             signer_to_remove: Signer,
-            signer_to_add: Signer
+            signer_to_add: Signer,
         ) {
             assert_only_self();
             let mut signer_list_comp = get_dep_component_mut!(ref self, SignerList);
@@ -147,7 +142,7 @@ mod multisig_component {
         }
 
         fn is_valid_signer_signature(
-            self: @ComponentState<TContractState>, hash: felt252, signer_signature: SignerSignature
+            self: @ComponentState<TContractState>, hash: felt252, signer_signature: SignerSignature,
         ) -> bool {
             let is_signer = self
                 .get_contract()
@@ -162,10 +157,10 @@ mod multisig_component {
         TContractState,
         +HasComponent<TContractState>,
         impl SignerList: signer_list_component::HasComponent<TContractState>,
-        +Drop<TContractState>
+        +Drop<TContractState>,
     > of IArgentMultisigInternal<ComponentState<TContractState>> {
         fn initialize(
-            ref self: ComponentState<TContractState>, threshold: usize, mut signers: Array<Signer>
+            ref self: ComponentState<TContractState>, threshold: usize, mut signers: Array<Signer>,
         ) {
             assert(self.threshold.read() == 0, 'argent/already-initialized');
 
@@ -180,14 +175,14 @@ mod multisig_component {
                 let signer_guid = guids.pop_front().unwrap();
                 signer_list_comp.emit(OwnerAddedGuid { new_owner_guid: signer_guid });
                 signer_list_comp.emit(SignerLinked { signer_guid, signer });
-            };
+            }
 
             self.threshold.write(threshold);
             self.emit(ThresholdUpdated { new_threshold: threshold });
         }
 
         fn assert_valid_threshold_and_signers_count(
-            self: @ComponentState<TContractState>, threshold: usize, signers_len: usize
+            self: @ComponentState<TContractState>, threshold: usize, signers_len: usize,
         ) {
             assert(threshold != 0, 'argent/invalid-threshold');
             assert(signers_len != 0, 'argent/invalid-signers-len');
@@ -198,7 +193,7 @@ mod multisig_component {
         fn assert_valid_storage(self: @ComponentState<TContractState>) {
             self
                 .assert_valid_threshold_and_signers_count(
-                    self.threshold.read(), self.get_contract().get_signers_len()
+                    self.threshold.read(), self.get_contract().get_signers_len(),
                 );
         }
 
@@ -206,14 +201,14 @@ mod multisig_component {
             self: @ComponentState<TContractState>,
             hash: felt252,
             threshold: u32,
-            mut signer_signatures: Array<SignerSignature>
+            mut signer_signatures: Array<SignerSignature>,
         ) -> bool {
             assert(signer_signatures.len() == threshold, 'argent/signature-invalid-length');
             let mut last_signer: u256 = 0;
             loop {
                 let signer_sig = match signer_signatures.pop_front() {
                     Option::Some(signer_sig) => signer_sig,
-                    Option::None => { break true; }
+                    Option::None => { break true; },
                 };
                 let signer_guid = signer_sig.signer().into_guid();
                 assert(self.is_signer_guid(signer_guid), 'argent/not-a-signer');

--- a/argent/src/offchain_message/interface.cairo
+++ b/argent/src/offchain_message/interface.cairo
@@ -37,8 +37,9 @@ struct StarkNetDomain {
     chain_id: felt252,
 }
 
-const STARKNET_DOMAIN_TYPE_HASH_REV_0: felt252 =
-    selector!("StarkNetDomain(name:felt,version:felt,chainId:felt)");
+const STARKNET_DOMAIN_TYPE_HASH_REV_0: felt252 = selector!(
+    "StarkNetDomain(name:felt,version:felt,chainId:felt)",
+);
 
 impl StructHashStarkNetDomain of IStructHashRev0<StarkNetDomain> {
     fn get_struct_hash_rev_0(self: @StarkNetDomain) -> felt252 {
@@ -59,22 +60,18 @@ struct StarknetDomain {
     revision: felt252,
 }
 
-const STARKNET_DOMAIN_TYPE_HASH_REV_1: felt252 =
-    selector!(
-        "\"StarknetDomain\"(\"name\":\"shortstring\",\"version\":\"shortstring\",\"chainId\":\"shortstring\",\"revision\":\"shortstring\")"
-    );
+const STARKNET_DOMAIN_TYPE_HASH_REV_1: felt252 = selector!(
+    "\"StarknetDomain\"(\"name\":\"shortstring\",\"version\":\"shortstring\",\"chainId\":\"shortstring\",\"revision\":\"shortstring\")",
+);
 
 impl StructHashStarknetDomain of IStructHashRev1<StarknetDomain> {
     fn get_struct_hash_rev_1(self: @StarknetDomain) -> felt252 {
         poseidon_hash_span(
             array![
-                STARKNET_DOMAIN_TYPE_HASH_REV_1,
-                *self.name,
-                *self.version,
-                *self.chain_id,
-                *self.revision
+                STARKNET_DOMAIN_TYPE_HASH_REV_1, *self.name, *self.version, *self.chain_id,
+                *self.revision,
             ]
-                .span()
+                .span(),
         )
     }
 }

--- a/argent/src/offchain_message/precalculated_hashing.cairo
+++ b/argent/src/offchain_message/precalculated_hashing.cairo
@@ -1,17 +1,17 @@
 use argent::offchain_message::interface::IStructHashRev1;
 use hash::HashStateTrait;
-use poseidon::{hades_permutation, HashState};
+use poseidon::{HashState, hades_permutation};
 use starknet::get_contract_address;
 
 fn get_message_hash_rev_1_with_precalc<T, +Drop<T>, +IStructHashRev1<T>>(
-    hades_permutation_state: (felt252, felt252, felt252), rev1_struct: T
+    hades_permutation_state: (felt252, felt252, felt252), rev1_struct: T,
 ) -> felt252 {
     // mainnet_domain_hash = domain.get_struct_hash_rev_1()
     // hades_permutation_state == hades_permutation('StarkNet Message', mainnet_domain_hash, 0);
     let (s0, s1, s2) = hades_permutation_state;
 
     let (fs0, fs1, fs2) = hades_permutation(
-        s0 + get_contract_address().into(), s1 + rev1_struct.get_struct_hash_rev_1(), s2
+        s0 + get_contract_address().into(), s1 + rev1_struct.get_struct_hash_rev_1(), s2,
     );
     HashState { s0: fs0, s1: fs1, s2: fs2, odd: false }.finalize()
 }

--- a/argent/src/outside_execution/interface.cairo
+++ b/argent/src/outside_execution/interface.cairo
@@ -1,6 +1,7 @@
 use hash::{HashStateExTrait, HashStateTrait};
 use pedersen::PedersenTrait;
-use starknet::{ContractAddress, get_contract_address, get_tx_info, account::Call};
+use starknet::account::Call;
+use starknet::{ContractAddress, get_contract_address, get_tx_info};
 
 // Interface ID for revision 0 of the OutsideExecute interface
 // see https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-9.md
@@ -27,7 +28,7 @@ struct OutsideExecution {
     nonce: felt252,
     execute_after: u64,
     execute_before: u64,
-    calls: Span<Call>
+    calls: Span<Call>,
 }
 
 /// @notice get_outside_execution_message_hash_rev_* is not part of the standard interface
@@ -40,12 +41,12 @@ trait IOutsideExecution<TContractState> {
     /// @notice This function does not allow reentrancy. A call to `__execute__` or
     /// `execute_from_outside` cannot trigger another nested transaction to `execute_from_outside`.
     fn execute_from_outside(
-        ref self: TContractState, outside_execution: OutsideExecution, signature: Array<felt252>
+        ref self: TContractState, outside_execution: OutsideExecution, signature: Array<felt252>,
     ) -> Array<Span<felt252>>;
 
     /// @notice Outside execution using SNIP-12 Rev 1
     fn execute_from_outside_v2(
-        ref self: TContractState, outside_execution: OutsideExecution, signature: Span<felt252>
+        ref self: TContractState, outside_execution: OutsideExecution, signature: Span<felt252>,
     ) -> Array<Span<felt252>>;
 
     /// Get the status of a given nonce, true if the nonce is available to use
@@ -54,13 +55,13 @@ trait IOutsideExecution<TContractState> {
     /// Get the message hash for some `OutsideExecution` rev 0 following Eip712. Can be used to know
     /// what needs to be signed
     fn get_outside_execution_message_hash_rev_0(
-        self: @TContractState, outside_execution: OutsideExecution
+        self: @TContractState, outside_execution: OutsideExecution,
     ) -> felt252;
 
     /// Get the message hash for some `OutsideExecution` rev 1 following Eip712. Can be used to know
     /// what needs to be signed
     fn get_outside_execution_message_hash_rev_1(
-        self: @TContractState, outside_execution: OutsideExecution
+        self: @TContractState, outside_execution: OutsideExecution,
     ) -> felt252;
 }
 

--- a/argent/src/outside_execution/outside_execution.cairo
+++ b/argent/src/outside_execution/outside_execution.cairo
@@ -2,20 +2,18 @@
 // This is achieved by adding outside_execution::ERC165_OUTSIDE_EXECUTION_INTERFACE_ID
 #[starknet::component]
 mod outside_execution_component {
-    use argent::outside_execution::{
-        outside_execution_hash::{
-            OffChainMessageOutsideExecutionRev0, OffChainMessageOutsideExecutionRev1
-        },
-        interface::{OutsideExecution, IOutsideExecutionCallback, IOutsideExecution}
+    use argent::outside_execution::interface::{
+        IOutsideExecution, IOutsideExecutionCallback, OutsideExecution,
     };
-    use hash::{HashStateTrait, HashStateExTrait};
-    use openzeppelin::security::reentrancyguard::{
-        ReentrancyGuardComponent, ReentrancyGuardComponent::InternalImpl
+    use argent::outside_execution::outside_execution_hash::{
+        OffChainMessageOutsideExecutionRev0, OffChainMessageOutsideExecutionRev1,
     };
+    use hash::{HashStateExTrait, HashStateTrait};
+    use openzeppelin::security::reentrancyguard::ReentrancyGuardComponent;
+    use openzeppelin::security::reentrancyguard::ReentrancyGuardComponent::InternalImpl;
     use pedersen::PedersenTrait;
-    use starknet::{
-        get_caller_address, get_contract_address, get_block_timestamp, get_tx_info, account::Call
-    };
+    use starknet::account::Call;
+    use starknet::{get_block_timestamp, get_caller_address, get_contract_address, get_tx_info};
 
     #[storage]
     struct Storage {
@@ -38,7 +36,7 @@ mod outside_execution_component {
         fn execute_from_outside(
             ref self: ComponentState<TContractState>,
             outside_execution: OutsideExecution,
-            signature: Array<felt252>
+            signature: Array<felt252>,
         ) -> Array<Span<felt252>> {
             let hash = outside_execution.get_message_hash_rev_0();
             self.assert_valid_outside_execution(outside_execution, hash, signature.span())
@@ -47,26 +45,26 @@ mod outside_execution_component {
         fn execute_from_outside_v2(
             ref self: ComponentState<TContractState>,
             outside_execution: OutsideExecution,
-            signature: Span<felt252>
+            signature: Span<felt252>,
         ) -> Array<Span<felt252>> {
             let hash = outside_execution.get_message_hash_rev_1();
             self.assert_valid_outside_execution(outside_execution, hash, signature)
         }
 
         fn get_outside_execution_message_hash_rev_0(
-            self: @ComponentState<TContractState>, outside_execution: OutsideExecution
+            self: @ComponentState<TContractState>, outside_execution: OutsideExecution,
         ) -> felt252 {
             outside_execution.get_message_hash_rev_0()
         }
 
         fn get_outside_execution_message_hash_rev_1(
-            self: @ComponentState<TContractState>, outside_execution: OutsideExecution
+            self: @ComponentState<TContractState>, outside_execution: OutsideExecution,
         ) -> felt252 {
             outside_execution.get_message_hash_rev_1()
         }
 
         fn is_valid_outside_execution_nonce(
-            self: @ComponentState<TContractState>, nonce: felt252
+            self: @ComponentState<TContractState>, nonce: felt252,
         ) -> bool {
             !self.outside_nonces.read(nonce)
         }
@@ -84,7 +82,7 @@ mod outside_execution_component {
             ref self: ComponentState<TContractState>,
             outside_execution: OutsideExecution,
             outside_tx_hash: felt252,
-            signature: Span<felt252>
+            signature: Span<felt252>,
         ) -> Array<Span<felt252>> {
             let mut reentrancy_guard = get_dep_component_mut!(ref self, ReentrancyGuard);
             reentrancy_guard.start();
@@ -97,7 +95,7 @@ mod outside_execution_component {
             assert(
                 outside_execution.execute_after < block_timestamp
                     && block_timestamp < outside_execution.execute_before,
-                'argent/invalid-timestamp'
+                'argent/invalid-timestamp',
             );
             let nonce = outside_execution.nonce;
             assert(!self.outside_nonces.read(nonce), 'argent/duplicated-outside-nonce');

--- a/argent/src/outside_execution/outside_execution_hash.cairo
+++ b/argent/src/outside_execution/outside_execution_hash.cairo
@@ -1,48 +1,43 @@
-use argent::offchain_message::{
-    interface::{
-        StarkNetDomain, StarknetDomain, StructHashStarkNetDomain, IOffChainMessageHashRev0,
-        IStructHashRev0, IOffChainMessageHashRev1, IStructHashRev1
-    },
-    precalculated_hashing::get_message_hash_rev_1_with_precalc
+use argent::offchain_message::interface::{
+    IOffChainMessageHashRev0, IOffChainMessageHashRev1, IStructHashRev0, IStructHashRev1,
+    StarkNetDomain, StarknetDomain, StructHashStarkNetDomain,
 };
-use argent::outside_execution::interface::{OutsideExecution};
-use hash::{HashStateTrait, HashStateExTrait};
+use argent::offchain_message::precalculated_hashing::get_message_hash_rev_1_with_precalc;
+use argent::outside_execution::interface::OutsideExecution;
+use hash::{HashStateExTrait, HashStateTrait};
 use pedersen::PedersenTrait;
-use poseidon::{poseidon_hash_span, hades_permutation, HashState};
-use starknet::{get_tx_info, get_contract_address, account::Call};
+use poseidon::{HashState, hades_permutation, poseidon_hash_span};
+use starknet::account::Call;
+use starknet::{get_contract_address, get_tx_info};
 
-const MAINNET_FIRST_HADES_PERMUTATION: (felt252, felt252, felt252) =
-    (
-        2727651893633223888261849279042022325174182119102281398572272198960815727249,
-        729016093840936084580216898033636860729342953928695140840860652272753125883,
-        2792630223211151632174198306610141883878913626231408099903852589995722964080
-    );
+const MAINNET_FIRST_HADES_PERMUTATION: (felt252, felt252, felt252) = (
+    2727651893633223888261849279042022325174182119102281398572272198960815727249,
+    729016093840936084580216898033636860729342953928695140840860652272753125883,
+    2792630223211151632174198306610141883878913626231408099903852589995722964080,
+);
 
-const SEPOLIA_FIRST_HADES_PERMUTATION: (felt252, felt252, felt252) =
-    (
-        3580606761507954093996364807837346681513890124685758374532511352257317798951,
-        3431227198346789440159663709265467470274870120429209591243179659934705045436,
-        974062396530052497724701732977002885691473732259823426261944148730229556466
-    );
+const SEPOLIA_FIRST_HADES_PERMUTATION: (felt252, felt252, felt252) = (
+    3580606761507954093996364807837346681513890124685758374532511352257317798951,
+    3431227198346789440159663709265467470274870120429209591243179659934705045436,
+    974062396530052497724701732977002885691473732259823426261944148730229556466,
+);
 
 
-const OUTSIDE_CALL_TYPE_HASH_REV_0: felt252 =
-    selector!("OutsideCall(to:felt,selector:felt,calldata_len:felt,calldata:felt*)");
+const OUTSIDE_CALL_TYPE_HASH_REV_0: felt252 = selector!(
+    "OutsideCall(to:felt,selector:felt,calldata_len:felt,calldata:felt*)",
+);
 
-const OUTSIDE_EXECUTION_TYPE_HASH_REV_0: felt252 =
-    selector!(
-        "OutsideExecution(caller:felt,nonce:felt,execute_after:felt,execute_before:felt,calls_len:felt,calls:OutsideCall*)OutsideCall(to:felt,selector:felt,calldata_len:felt,calldata:felt*)"
-    );
+const OUTSIDE_EXECUTION_TYPE_HASH_REV_0: felt252 = selector!(
+    "OutsideExecution(caller:felt,nonce:felt,execute_after:felt,execute_before:felt,calls_len:felt,calls:OutsideCall*)OutsideCall(to:felt,selector:felt,calldata_len:felt,calldata:felt*)",
+);
 
-const OUTSIDE_EXECUTION_TYPE_HASH_REV_1: felt252 =
-    selector!(
-        "\"OutsideExecution\"(\"Caller\":\"ContractAddress\",\"Nonce\":\"felt\",\"Execute After\":\"u128\",\"Execute Before\":\"u128\",\"Calls\":\"Call*\")\"Call\"(\"To\":\"ContractAddress\",\"Selector\":\"selector\",\"Calldata\":\"felt*\")"
-    );
+const OUTSIDE_EXECUTION_TYPE_HASH_REV_1: felt252 = selector!(
+    "\"OutsideExecution\"(\"Caller\":\"ContractAddress\",\"Nonce\":\"felt\",\"Execute After\":\"u128\",\"Execute Before\":\"u128\",\"Calls\":\"Call*\")\"Call\"(\"To\":\"ContractAddress\",\"Selector\":\"selector\",\"Calldata\":\"felt*\")",
+);
 
-const CALL_TYPE_HASH_REV_1: felt252 =
-    selector!(
-        "\"Call\"(\"To\":\"ContractAddress\",\"Selector\":\"selector\",\"Calldata\":\"felt*\")"
-    );
+const CALL_TYPE_HASH_REV_1: felt252 = selector!(
+    "\"Call\"(\"To\":\"ContractAddress\",\"Selector\":\"selector\",\"Calldata\":\"felt*\")",
+);
 
 impl StructHashOutsideExecutionRev0 of IStructHashRev0<OutsideExecution> {
     fn get_struct_hash_rev_0(self: @OutsideExecution) -> felt252 {
@@ -115,12 +110,10 @@ impl StructHashCallRev1 of IStructHashRev1<Call> {
     fn get_struct_hash_rev_1(self: @Call) -> felt252 {
         poseidon_hash_span(
             array![
-                CALL_TYPE_HASH_REV_1,
-                (*self.to).into(),
-                *self.selector,
-                poseidon_hash_span(*self.calldata)
+                CALL_TYPE_HASH_REV_1, (*self.to).into(), *self.selector,
+                poseidon_hash_span(*self.calldata),
             ]
-                .span()
+                .span(),
         )
     }
 }
@@ -133,17 +126,14 @@ impl StructHashOutsideExecutionRev1 of IStructHashRev1<OutsideExecution> {
 
         while let Option::Some(call) = calls_span.pop_front() {
             hashed_calls.append(call.get_struct_hash_rev_1());
-        };
+        }
         poseidon_hash_span(
             array![
-                OUTSIDE_EXECUTION_TYPE_HASH_REV_1,
-                self.caller.into(),
-                self.nonce,
-                self.execute_after.into(),
-                self.execute_before.into(),
+                OUTSIDE_EXECUTION_TYPE_HASH_REV_1, self.caller.into(), self.nonce,
+                self.execute_after.into(), self.execute_before.into(),
                 poseidon_hash_span(hashed_calls.span()),
             ]
-                .span()
+                .span(),
         )
     }
 }
@@ -163,16 +153,14 @@ impl OffChainMessageOutsideExecutionRev1 of IOffChainMessageHashRev1<OutsideExec
             return get_message_hash_rev_1_with_precalc(SEPOLIA_FIRST_HADES_PERMUTATION, *self);
         }
         let domain = StarknetDomain {
-            name: 'Account.execute_from_outside', version: 2, chain_id, revision: 1
+            name: 'Account.execute_from_outside', version: 2, chain_id, revision: 1,
         };
         poseidon_hash_span(
             array![
-                'StarkNet Message',
-                domain.get_struct_hash_rev_1(),
-                get_contract_address().into(),
+                'StarkNet Message', domain.get_struct_hash_rev_1(), get_contract_address().into(),
                 (*self).get_struct_hash_rev_1(),
             ]
-                .span()
+                .span(),
         )
     }
 }

--- a/argent/src/recovery/interface.cairo
+++ b/argent/src/recovery/interface.cairo
@@ -1,11 +1,11 @@
-use argent::signer::signer_signature::{Signer, SignerStorageValue, SignerSignature, SignerType};
+use argent::signer::signer_signature::{Signer, SignerSignature, SignerStorageValue, SignerType};
 use argent::utils::array_store::StoreFelt252Array;
 use starknet::ContractAddress;
 
 #[starknet::interface]
 trait IRecovery<TContractState> {
     fn trigger_escape(
-        ref self: TContractState, target_signers: Array<Signer>, new_signers: Array<Signer>
+        ref self: TContractState, target_signers: Array<Signer>, new_signers: Array<Signer>,
     );
     fn execute_escape(ref self: TContractState);
     fn cancel_escape(ref self: TContractState);
@@ -21,7 +21,7 @@ trait IRecovery<TContractState> {
 struct EscapeTriggered {
     ready_at: u64,
     target_signers: Span<felt252>,
-    new_signers: Span<felt252>
+    new_signers: Span<felt252>,
 }
 
 /// @notice Signer escape was completed
@@ -30,7 +30,7 @@ struct EscapeTriggered {
 #[derive(Drop, starknet::Event)]
 struct EscapeExecuted {
     target_signers: Span<felt252>,
-    new_signers: Span<felt252>
+    new_signers: Span<felt252>,
 }
 
 /// @notice Signer escape was canceled
@@ -39,7 +39,7 @@ struct EscapeExecuted {
 #[derive(Drop, starknet::Event)]
 struct EscapeCanceled {
     target_signers: Span<felt252>,
-    new_signers: Span<felt252>
+    new_signers: Span<felt252>,
 }
 
 /// @notice The status of the Escape
@@ -84,7 +84,7 @@ enum LegacyEscapeType {
     #[default]
     None,
     Guardian,
-    Owner
+    Owner,
 }
 
 /// @notice The Legacy Escape (only used in the ArgentAccount)
@@ -134,7 +134,7 @@ impl PackEscape of starknet::StorePacking<Escape, Array<felt252>> {
         while let Option::Some(target_signer) = target_signers_span.pop_front() {
             arr.append(*target_signer);
             arr.append(*new_signers_span.pop_front().expect('argent/invalid-array-len'));
-        };
+        }
         arr
     }
 
@@ -151,15 +151,15 @@ impl PackEscape of starknet::StorePacking<Escape, Array<felt252>> {
                 let target_signer = value_span.pop_front();
                 let new_signer = match value_span.pop_front() {
                     Option::Some(item) => *item,
-                    Option::None => { break; }
+                    Option::None => { break; },
                 };
                 target_signers.append(*target_signer.unwrap());
                 new_signers.append(new_signer);
-            };
+            }
             Escape {
                 ready_at: ready_at.try_into().unwrap(),
                 target_signers: target_signers,
-                new_signers: new_signers
+                new_signers: new_signers,
             }
         }
     }
@@ -174,9 +174,9 @@ impl LegacyEscapeStorePacking of starknet::StorePacking<LegacyEscape, (felt252, 
     fn pack(value: LegacyEscape) -> (felt252, felt252) {
         let (signer_type_ordinal, stored_value) = match value.new_signer {
             Option::Some(new_signer) => (
-                new_signer.signer_type.into(), new_signer.stored_value.into()
+                new_signer.signer_type.into(), new_signer.stored_value.into(),
             ),
-            Option::None => (0, 0)
+            Option::None => (0, 0),
         };
         let packed = value.ready_at.into()
             + (value.escape_type.into() * SHIFT_64)
@@ -198,7 +198,7 @@ impl LegacyEscapeStorePacking of starknet::StorePacking<LegacyEscape, (felt252, 
                 let signer_type = signer_type_ordinal.try_into().unwrap();
                 let stored_value = stored_value.try_into().unwrap();
                 Option::Some(SignerStorageValue { signer_type, stored_value })
-            }
+            },
         }
     }
 }
@@ -209,7 +209,7 @@ impl EscapeTypeIntoFelt252 of Into<LegacyEscapeType, felt252> {
         match self {
             LegacyEscapeType::None => 0,
             LegacyEscapeType::Guardian => 1,
-            LegacyEscapeType::Owner => 2
+            LegacyEscapeType::Owner => 2,
         }
     }
 }

--- a/argent/src/recovery/threshold_recovery.cairo
+++ b/argent/src/recovery/threshold_recovery.cairo
@@ -6,7 +6,7 @@ use starknet::ContractAddress;
 #[starknet::interface]
 trait IToggleThresholdRecovery<TContractState> {
     fn toggle_escape(
-        ref self: TContractState, is_enabled: bool, security_period: u64, expiry_period: u64
+        ref self: TContractState, is_enabled: bool, security_period: u64, expiry_period: u64,
     );
 }
 
@@ -17,7 +17,7 @@ trait IThresholdRecoveryInternal<TContractState> {
         to: ContractAddress,
         selector: felt252,
         calldata: Span<felt252>,
-        threshold: u32
+        threshold: u32,
     ) -> Option<(u32, felt252)>;
 }
 
@@ -27,20 +27,19 @@ trait IThresholdRecoveryInternal<TContractState> {
 #[starknet::component]
 mod threshold_recovery_component {
     use argent::recovery::interface::{
-        Escape, EscapeEnabled, EscapeStatus, IRecovery, EscapeExecuted, EscapeTriggered,
-        EscapeCanceled
+        Escape, EscapeCanceled, EscapeEnabled, EscapeExecuted, EscapeStatus, EscapeTriggered,
+        IRecovery,
     };
     use argent::signer::signer_signature::{Signer, SignerTrait};
     use argent::signer_storage::interface::ISignerList;
-    use argent::signer_storage::signer_list::{
-        signer_list_component,
-        signer_list_component::{
-            SignerListInternalImpl, OwnerAddedGuid, OwnerRemovedGuid, SignerLinked
-        }
+    use argent::signer_storage::signer_list::signer_list_component;
+    use argent::signer_storage::signer_list::signer_list_component::{
+        OwnerAddedGuid, OwnerRemovedGuid, SignerLinked, SignerListInternalImpl,
     };
     use argent::utils::asserts::assert_only_self;
     use core::array::ArrayTrait;
-    use starknet::{get_block_timestamp, get_contract_address, ContractAddress, account::Call};
+    use starknet::account::Call;
+    use starknet::{ContractAddress, get_block_timestamp, get_contract_address};
     use super::{IThresholdRecoveryInternal, IToggleThresholdRecovery};
 
     #[storage]
@@ -62,18 +61,18 @@ mod threshold_recovery_component {
         TContractState,
         +HasComponent<TContractState>,
         impl SignerList: signer_list_component::HasComponent<TContractState>,
-        +Drop<TContractState>
+        +Drop<TContractState>,
     > of IRecovery<ComponentState<TContractState>> {
         /// @notice Triggers the escape. The function must be called through the __validate__ method
         /// and authorized by threshold-1 signers.
         fn trigger_escape(
             ref self: ComponentState<TContractState>,
             target_signers: Array<Signer>,
-            new_signers: Array<Signer>
+            new_signers: Array<Signer>,
         ) {
             assert_only_self();
             assert(
-                target_signers.len() == 1 && new_signers.len() == 1, 'argent/invalid-escape-length'
+                target_signers.len() == 1 && new_signers.len() == 1, 'argent/invalid-escape-length',
             );
 
             let escape_config: EscapeEnabled = self.escape_enabled.read();
@@ -97,14 +96,14 @@ mod threshold_recovery_component {
                     self
                         .get_contract()
                         .is_signer_before(current_escaped_signer, target_signer_guid),
-                    'argent/cannot-override-escape'
+                    'argent/cannot-override-escape',
                 );
             }
             let ready_at = get_block_timestamp() + escape_config.security_period;
             let escape = Escape {
                 ready_at,
                 target_signers: array![target_signer_guid],
-                new_signers: array![new_signer_guid]
+                new_signers: array![new_signer_guid],
             };
             self.escape.write(escape);
             self
@@ -112,8 +111,8 @@ mod threshold_recovery_component {
                     EscapeTriggered {
                         ready_at,
                         target_signers: array![target_signer_guid].span(),
-                        new_signers: array![new_signer_guid].span()
-                    }
+                        new_signers: array![new_signer_guid].span(),
+                    },
                 );
         }
 
@@ -138,8 +137,8 @@ mod threshold_recovery_component {
                 .emit(
                     EscapeExecuted {
                         target_signers: current_escape.target_signers.span(),
-                        new_signers: current_escape.new_signers.span()
-                    }
+                        new_signers: current_escape.new_signers.span(),
+                    },
                 );
             signer_list_comp.emit(OwnerRemovedGuid { removed_owner_guid: target_signer_guid });
             signer_list_comp.emit(OwnerAddedGuid { new_owner_guid: new_signer_guid });
@@ -185,13 +184,13 @@ mod threshold_recovery_component {
 
     #[embeddable_as(ToggleThresholdRecoveryImpl)]
     impl ToggleThresholdRecovery<
-        TContractState, +HasComponent<TContractState>
+        TContractState, +HasComponent<TContractState>,
     > of IToggleThresholdRecovery<ComponentState<TContractState>> {
         fn toggle_escape(
             ref self: ComponentState<TContractState>,
             is_enabled: bool,
             security_period: u64,
-            expiry_period: u64
+            expiry_period: u64,
         ) {
             assert_only_self();
             // cannot toggle escape if there is an ongoing escape
@@ -202,7 +201,7 @@ mod threshold_recovery_component {
             assert(
                 current_escape.target_signers.len() == 0
                     || current_escape_status == EscapeStatus::Expired,
-                'argent/ongoing-escape'
+                'argent/ongoing-escape',
             );
 
             if is_enabled {
@@ -222,21 +221,21 @@ mod threshold_recovery_component {
 
     #[embeddable_as(ThresholdRecoveryInternalImpl)]
     impl ThresholdRecoveryInternal<
-        TContractState, +HasComponent<TContractState>, +ISignerList<TContractState>
+        TContractState, +HasComponent<TContractState>, +ISignerList<TContractState>,
     > of IThresholdRecoveryInternal<ComponentState<TContractState>> {
         fn parse_escape_call(
             self: @ComponentState<TContractState>,
             to: ContractAddress,
             selector: felt252,
             mut calldata: Span<felt252>,
-            threshold: u32
+            threshold: u32,
         ) -> Option<(u32, felt252)> {
             if to == get_contract_address() {
                 if selector == selector!("trigger_escape_signer") {
                     // check we can do recovery
                     let escape_config: EscapeEnabled = self.escape_enabled.read();
                     assert(
-                        escape_config.is_enabled && threshold > 1, 'argent/recovery-unavailable'
+                        escape_config.is_enabled && threshold > 1, 'argent/recovery-unavailable',
                     );
                     // get escaped signer
                     let escaped_signer: Signer = Serde::deserialize(ref calldata)
@@ -251,7 +250,7 @@ mod threshold_recovery_component {
                     // check we can do recovery
                     let escape_config: EscapeEnabled = self.escape_enabled.read();
                     assert(
-                        escape_config.is_enabled && threshold > 1, 'argent/recovery-unavailable'
+                        escape_config.is_enabled && threshold > 1, 'argent/recovery-unavailable',
                     );
                     // get escaped signer
                     let current_escape: Escape = self.escape.read();
@@ -267,7 +266,7 @@ mod threshold_recovery_component {
     #[generate_trait]
     impl Private<TContractState, +HasComponent<TContractState>> of PrivateTrait<TContractState> {
         fn get_escape_status(
-            self: @ComponentState<TContractState>, escape_ready_at: u64, expiry_period: u64
+            self: @ComponentState<TContractState>, escape_ready_at: u64, expiry_period: u64,
         ) -> EscapeStatus {
             if escape_ready_at == 0 {
                 return EscapeStatus::None;

--- a/argent/src/session/interface.cairo
+++ b/argent/src/session/interface.cairo
@@ -1,7 +1,7 @@
 use argent::signer::signer_signature::SignerSignature;
 use poseidon::poseidon_hash_span;
 use starknet::account::Call;
-use starknet::{get_tx_info, get_contract_address, ContractAddress};
+use starknet::{ContractAddress, get_contract_address, get_tx_info};
 
 /// @notice Session struct that the owner and guardian has to sign to initiate a session
 /// @dev The hash of the session is also signed by the guardian (backend) and
@@ -45,7 +45,7 @@ trait ISessionCallback<TContractState> {
     /// @param authorization_signature The owner + guardian signature of the session
     /// @return The parsed array of SignerSignature
     fn parse_and_verify_authorization(
-        self: @TContractState, session_hash: felt252, authorization_signature: Span<felt252>
+        self: @TContractState, session_hash: felt252, authorization_signature: Span<felt252>,
     ) -> Array<SignerSignature>;
 }
 

--- a/argent/src/session/session_hash.cairo
+++ b/argent/src/session/session_hash.cairo
@@ -1,45 +1,40 @@
-use argent::offchain_message::{
-    interface::{
-        StarknetDomain, StructHashStarknetDomain, IMerkleLeafHash, IStructHashRev1,
-        IOffChainMessageHashRev1,
-    },
-    precalculated_hashing::get_message_hash_rev_1_with_precalc
+use argent::offchain_message::interface::{
+    IMerkleLeafHash, IOffChainMessageHashRev1, IStructHashRev1, StarknetDomain,
+    StructHashStarknetDomain,
 };
+use argent::offchain_message::precalculated_hashing::get_message_hash_rev_1_with_precalc;
 use argent::session::interface::Session;
 use hash::{HashStateExTrait, HashStateTrait};
-use poseidon::{hades_permutation, poseidon_hash_span, HashState};
-use starknet::{get_contract_address, get_tx_info, account::Call};
+use poseidon::{HashState, hades_permutation, poseidon_hash_span};
+use starknet::account::Call;
+use starknet::{get_contract_address, get_tx_info};
 
 
-const MAINNET_FIRST_HADES_PERMUTATION: (felt252, felt252, felt252) =
-    (
-        3159357451750963173197764487250193801745009044296318704413979805593222351753,
-        2856607116111318915813829371903536205200021468882518469573183227809900863246,
-        2405333218043798385503929428387279699579326006043041470088260529024671365157
-    );
+const MAINNET_FIRST_HADES_PERMUTATION: (felt252, felt252, felt252) = (
+    3159357451750963173197764487250193801745009044296318704413979805593222351753,
+    2856607116111318915813829371903536205200021468882518469573183227809900863246,
+    2405333218043798385503929428387279699579326006043041470088260529024671365157,
+);
 
-const SEPOLIA_FIRST_HADES_PERMUTATION: (felt252, felt252, felt252) =
-    (
-        691798498452391354097240300284680479233893583850648846821812933705410085810,
-        317062340895242311773051982041708757540909251525159061717012359096590796798,
-        517893314125397876808992724850240644188517690767234330219248407741294215037
-    );
+const SEPOLIA_FIRST_HADES_PERMUTATION: (felt252, felt252, felt252) = (
+    691798498452391354097240300284680479233893583850648846821812933705410085810,
+    317062340895242311773051982041708757540909251525159061717012359096590796798,
+    517893314125397876808992724850240644188517690767234330219248407741294215037,
+);
 
 
-const SESSION_TYPE_HASH_REV_1: felt252 =
-    selector!(
-        "\"Session\"(\"Expires At\":\"timestamp\",\"Allowed Methods\":\"merkletree\",\"Metadata\":\"string\",\"Session Key\":\"felt\")"
-    );
+const SESSION_TYPE_HASH_REV_1: felt252 = selector!(
+    "\"Session\"(\"Expires At\":\"timestamp\",\"Allowed Methods\":\"merkletree\",\"Metadata\":\"string\",\"Session Key\":\"felt\")",
+);
 
-const ALLOWED_METHOD_HASH_REV_1: felt252 =
-    selector!(
-        "\"Allowed Method\"(\"Contract Address\":\"ContractAddress\",\"selector\":\"selector\")"
-    );
+const ALLOWED_METHOD_HASH_REV_1: felt252 = selector!(
+    "\"Allowed Method\"(\"Contract Address\":\"ContractAddress\",\"selector\":\"selector\")",
+);
 
 impl MerkleLeafHash of IMerkleLeafHash<Call> {
     fn get_merkle_leaf(self: @Call) -> felt252 {
         poseidon_hash_span(
-            array![ALLOWED_METHOD_HASH_REV_1, (*self.to).into(), *self.selector].span()
+            array![ALLOWED_METHOD_HASH_REV_1, (*self.to).into(), *self.selector].span(),
         )
     }
 }
@@ -49,13 +44,10 @@ impl StructHashSession of IStructHashRev1<Session> {
         let self = *self;
         poseidon_hash_span(
             array![
-                SESSION_TYPE_HASH_REV_1,
-                self.expires_at.into(),
-                self.allowed_methods_root,
-                self.metadata_hash,
-                self.session_key_guid
+                SESSION_TYPE_HASH_REV_1, self.expires_at.into(), self.allowed_methods_root,
+                self.metadata_hash, self.session_key_guid,
             ]
-                .span()
+                .span(),
         )
     }
 }
@@ -74,12 +66,10 @@ impl OffChainMessageHashSessionRev1 of IOffChainMessageHashRev1<Session> {
         };
         poseidon_hash_span(
             array![
-                'StarkNet Message',
-                domain.get_struct_hash_rev_1(),
-                get_contract_address().into(),
-                self.get_struct_hash_rev_1()
+                'StarkNet Message', domain.get_struct_hash_rev_1(), get_contract_address().into(),
+                self.get_struct_hash_rev_1(),
             ]
-                .span()
+                .span(),
         )
     }
 }

--- a/argent/src/signer/eip191.cairo
+++ b/argent/src/signer/eip191.cairo
@@ -1,12 +1,12 @@
 use argent::signer::signer_signature::{Eip191Signer, is_valid_secp256k1_signature};
-use integer::{u128_byte_reverse, u256_safe_div_rem, u256_as_non_zero};
+use integer::{u128_byte_reverse, u256_as_non_zero, u256_safe_div_rem};
 use keccak::cairo_keccak;
-use starknet::secp256_trait::{Signature as Secp256Signature};
+use starknet::secp256_trait::Signature as Secp256Signature;
 
 #[must_use]
 #[inline(always)]
 fn is_valid_eip191_signature(
-    hash: felt252, signer: Eip191Signer, signature: Secp256Signature
+    hash: felt252, signer: Eip191Signer, signature: Secp256Signature,
 ) -> bool {
     is_valid_secp256k1_signature(calculate_eip191_hash(hash), signer.eth_address.into(), signature)
 }
@@ -38,9 +38,7 @@ fn calculate_eip191_hash(message: felt252) -> u256 {
         0x7565726568744519, // = to_le(0x1945746865726575), 
         0x64656E676953206D, // = to_le(0x6d205369676e6564),
         0x6567617373654D20, // = to_le(0x204d657373616765), 
-        to_le(0x3a0a333200000000 + tx_hash_part_1),
-        to_le(tx_hash_part_2),
-        to_le(tx_hash_part_3),
+        to_le(0x3a0a333200000000 + tx_hash_part_1), to_le(tx_hash_part_2), to_le(tx_hash_part_3),
         to_le(tx_hash_part_4),
     ];
     // last part needs padded at the end with the missing 4 bytes

--- a/argent/src/signer/signer_signature.cairo
+++ b/argent/src/signer/signer_signature.cairo
@@ -4,14 +4,14 @@ use argent::utils::hashing::poseidon_2;
 use core::traits::TryInto;
 use ecdsa::check_ecdsa_signature;
 use hash::{HashStateExTrait, HashStateTrait};
-use poseidon::{hades_permutation, PoseidonTrait};
-use starknet::SyscallResultTrait;
+use poseidon::{PoseidonTrait, hades_permutation};
+use starknet::eth_signature::is_eth_signature_valid;
 use starknet::secp256_trait::{
-    Secp256PointTrait, Signature as Secp256Signature, recover_public_key, is_signature_entry_valid
+    Secp256PointTrait, Signature as Secp256Signature, is_signature_entry_valid, recover_public_key,
 };
 use starknet::secp256k1::Secp256k1Point;
 use starknet::secp256r1::Secp256r1Point;
-use starknet::{EthAddress, eth_signature::is_eth_signature_valid};
+use starknet::{EthAddress, SyscallResultTrait};
 
 /// All signer type magic values. Used to derive their guid
 const STARKNET_SIGNER_TYPE: felt252 = 'Starknet Signer';
@@ -75,28 +75,28 @@ struct SignerStorageValue {
 /// @param pubkey the public key as felt252 for a starknet signature. Cannot be zero
 #[derive(Drop, Copy, Serde, PartialEq)]
 struct StarknetSigner {
-    pubkey: NonZero<felt252>
+    pubkey: NonZero<felt252>,
 }
 
 /// @notice The Secp256k1 signer using the Secp256k1 elliptic curve
 /// @param pubkey_hash the right-most 160 bits of a Keccak hash of an ECDSA public key
 #[derive(Drop, Copy, PartialEq)]
 struct Secp256k1Signer {
-    pubkey_hash: EthAddress
+    pubkey_hash: EthAddress,
 }
 
 /// @notice The Secp256r1 signer using the Secp256r1 elliptic curve
 /// @param pubkey the public key as a u256. Cannot be zero
 #[derive(Drop, Copy, Serde, PartialEq)]
 struct Secp256r1Signer {
-    pubkey: NonZero<u256>
+    pubkey: NonZero<u256>,
 }
 
 /// @notice The Eip191Signer signer conforming to the EIP-191 standard
 /// @param eth_address the ethereum address that signed the data
 #[derive(Drop, Copy, PartialEq)]
 struct Eip191Signer {
-    eth_address: EthAddress
+    eth_address: EthAddress,
 }
 
 /// @notice The webauthn signer
@@ -107,7 +107,7 @@ struct Eip191Signer {
 struct WebauthnSigner {
     origin: Span<u8>,
     rp_id_hash: NonZero<u256>,
-    pubkey: NonZero<u256>
+    pubkey: NonZero<u256>,
 }
 
 // Ensures that the pubkey_hash is not zero as we can't do NonZero<EthAddress>
@@ -150,7 +150,7 @@ impl SignerTraitImpl of SignerTrait {
         match self {
             Signer::Starknet(signer) => poseidon_2(STARKNET_SIGNER_TYPE, signer.pubkey.into()),
             Signer::Secp256k1(signer) => poseidon_2(
-                SECP256K1_SIGNER_TYPE, signer.pubkey_hash.address.into()
+                SECP256K1_SIGNER_TYPE, signer.pubkey_hash.address.into(),
             ),
             Signer::Secp256r1(signer) => {
                 let pubkey: u256 = signer.pubkey.into();
@@ -160,7 +160,7 @@ impl SignerTraitImpl of SignerTrait {
                     .finalize()
             },
             Signer::Eip191(signer) => poseidon_2(
-                EIP191_SIGNER_TYPE, signer.eth_address.address.into()
+                EIP191_SIGNER_TYPE, signer.eth_address.address.into(),
             ),
             Signer::Webauthn(signer) => {
                 let mut origin = signer.origin;
@@ -172,7 +172,7 @@ impl SignerTraitImpl of SignerTrait {
 
                 while let Option::Some(byte) = origin.pop_front() {
                     hash_state = hash_state.update_with(*byte);
-                };
+                }
                 hash_state.update_with(rp_id_hash).update_with(pubkey).finalize()
             },
         }
@@ -181,23 +181,23 @@ impl SignerTraitImpl of SignerTrait {
     fn storage_value(self: Signer) -> SignerStorageValue {
         match self {
             Signer::Starknet(signer) => SignerStorageValue {
-                signer_type: SignerType::Starknet, stored_value: signer.pubkey.into()
+                signer_type: SignerType::Starknet, stored_value: signer.pubkey.into(),
             },
             Signer::Secp256k1(signer) => SignerStorageValue {
                 signer_type: SignerType::Secp256k1,
-                stored_value: signer.pubkey_hash.address.try_into().unwrap()
+                stored_value: signer.pubkey_hash.address.try_into().unwrap(),
             },
             Signer::Secp256r1 => SignerStorageValue {
                 signer_type: SignerType::Secp256r1,
-                stored_value: self.into_guid().try_into().unwrap()
+                stored_value: self.into_guid().try_into().unwrap(),
             },
             Signer::Eip191(signer) => SignerStorageValue {
                 signer_type: SignerType::Eip191,
-                stored_value: signer.eth_address.address.try_into().unwrap()
+                stored_value: signer.eth_address.address.try_into().unwrap(),
             },
             Signer::Webauthn => SignerStorageValue {
                 signer_type: SignerType::Webauthn,
-                stored_value: self.into_guid().try_into().unwrap()
+                stored_value: self.into_guid().try_into().unwrap(),
             },
         }
     }
@@ -255,19 +255,19 @@ impl SignerSignatureImpl of SignerSignatureTrait {
     fn is_valid_signature(self: SignerSignature, hash: felt252) -> bool {
         match self {
             SignerSignature::Starknet((
-                signer, signature
+                signer, signature,
             )) => is_valid_starknet_signature(hash, signer, signature),
             SignerSignature::Secp256k1((
-                signer, signature
+                signer, signature,
             )) => is_valid_secp256k1_signature(hash.into(), signer.pubkey_hash.into(), signature),
             SignerSignature::Secp256r1((
-                signer, signature
+                signer, signature,
             )) => is_valid_secp256r1_signature(hash.into(), signer, signature),
             SignerSignature::Eip191((
-                signer, signature
+                signer, signature,
             )) => is_valid_eip191_signature(hash, signer, signature),
             SignerSignature::Webauthn((
-                signer, signature
+                signer, signature,
             )) => is_valid_webauthn_signature(hash, signer, signature),
         }
     }
@@ -278,7 +278,7 @@ impl SignerSignatureImpl of SignerSignatureTrait {
             SignerSignature::Secp256k1((signer, _)) => Signer::Secp256k1(signer),
             SignerSignature::Secp256r1((signer, _)) => Signer::Secp256r1(signer),
             SignerSignature::Eip191((signer, _)) => Signer::Eip191(signer),
-            SignerSignature::Webauthn((signer, _)) => Signer::Webauthn(signer)
+            SignerSignature::Webauthn((signer, _)) => Signer::Webauthn(signer),
         }
     }
 }
@@ -317,14 +317,14 @@ impl U256TryIntoSignerType of TryInto<u256, SignerType> {
 
 #[inline(always)]
 fn is_valid_starknet_signature(
-    hash: felt252, signer: StarknetSigner, signature: StarknetSignature
+    hash: felt252, signer: StarknetSigner, signature: StarknetSignature,
 ) -> bool {
     check_ecdsa_signature(hash, signer.pubkey.into(), signature.r, signature.s)
 }
 
 #[inline(always)]
 fn is_valid_secp256k1_signature(
-    hash: u256, pubkey_hash: EthAddress, signature: Secp256Signature
+    hash: u256, pubkey_hash: EthAddress, signature: Secp256Signature,
 ) -> bool {
     assert(signature.s <= SECP_256_K1_HALF, 'argent/malleable-signature');
     is_eth_signature_valid(hash, signature, pubkey_hash).is_ok()
@@ -332,7 +332,7 @@ fn is_valid_secp256k1_signature(
 
 #[inline(always)]
 fn is_valid_secp256r1_signature(
-    hash: u256, signer: Secp256r1Signer, signature: Secp256Signature
+    hash: u256, signer: Secp256r1Signer, signature: Secp256Signature,
 ) -> bool {
     // `recover_public_key` accepts invalid values for r and s, so we need to check them first
     assert(is_signature_entry_valid::<Secp256r1Point>(signature.r), 'argent/invalid-r-value');
@@ -346,13 +346,13 @@ fn is_valid_secp256r1_signature(
 
 #[inline(always)]
 fn is_valid_webauthn_signature(
-    hash: felt252, signer: WebauthnSigner, signature: WebauthnSignature
+    hash: felt252, signer: WebauthnSigner, signature: WebauthnSignature,
 ) -> bool {
     verify_authenticator_flags(signature.flags);
 
     let signed_hash = get_webauthn_hash(hash, signer, signature);
     is_valid_secp256r1_signature(
-        signed_hash, Secp256r1Signer { pubkey: signer.pubkey }, signature.ec_signature
+        signed_hash, Secp256r1Signer { pubkey: signer.pubkey }, signature.ec_signature,
     )
 }
 
@@ -368,7 +368,7 @@ impl SignerSpanTraitImpl of SignerSpanTrait {
         let mut guids = array![];
         while let Option::Some(signer) = self.pop_front() {
             guids.append((*signer).into_guid());
-        };
+        }
         guids
     }
 }

--- a/argent/src/signer/webauthn.cairo
+++ b/argent/src/signer/webauthn.cairo
@@ -1,11 +1,11 @@
 use alexandria_encoding::base64::Base64UrlEncoder;
-use alexandria_math::sha256::{sha256};
-use argent::signer::signer_signature::{WebauthnSigner};
+use alexandria_math::sha256::sha256;
+use argent::signer::signer_signature::WebauthnSigner;
 use argent::utils::array_ext::ArrayExtTrait;
 use argent::utils::bytes::{
-    SpanU8TryIntoU256, SpanU8TryIntoFelt252, u32s_to_u256, u32s_to_u8s, u256_to_u8s
+    SpanU8TryIntoFelt252, SpanU8TryIntoU256, u256_to_u8s, u32s_to_u256, u32s_to_u8s,
 };
-use argent::utils::hashing::{sha256_cairo0};
+use argent::utils::hashing::sha256_cairo0;
 use starknet::secp256_trait::Signature;
 
 /// @notice The webauthn signature that needs to be validated
@@ -56,7 +56,7 @@ fn verify_authenticator_flags(flags: u8) {
 /// Spec: https://www.w3.org/TR/webauthn/#dictdef-collectedclientdata
 /// Encoding spec: https://www.w3.org/TR/webauthn/#clientdatajson-verification
 fn encode_client_data_json(
-    hash: felt252, signature: WebauthnSignature, origin: Span<u8>
+    hash: felt252, signature: WebauthnSignature, origin: Span<u8>,
 ) -> Span<u8> {
     let mut json = client_data_json_intro();
     json.append_all(encode_challenge(hash, signature.sha256_implementation));
@@ -65,7 +65,7 @@ fn encode_client_data_json(
     json
         .append_all(
             array!['"', ',', '"', 'c', 'r', 'o', 's', 's', 'O', 'r', 'i', 'g', 'i', 'n', '"', ':']
-                .span()
+                .span(),
         );
     if signature.cross_origin {
         json.append_all(array!['t', 'r', 'u', 'e'].span());
@@ -89,7 +89,7 @@ fn encode_challenge(hash: felt252, sha256_implementation: Sha256Implementation) 
     };
     bytes.append(last_byte);
     assert!(
-        bytes.len() == 33, "webauthn/invalid-challenge-length"
+        bytes.len() == 33, "webauthn/invalid-challenge-length",
     ); // remove '=' signs if this assert fails
     Base64UrlEncoder::encode(bytes).span()
 }
@@ -102,7 +102,7 @@ fn encode_authenticator_data(signature: WebauthnSignature, rp_id_hash: u256) -> 
 }
 
 fn get_webauthn_hash_cairo0(
-    hash: felt252, signer: WebauthnSigner, signature: WebauthnSignature
+    hash: felt252, signer: WebauthnSigner, signature: WebauthnSignature,
 ) -> Option<u256> {
     let client_data_json = encode_client_data_json(hash, signature, signer.origin);
     let client_data_hash = u32s_to_u8s(sha256_cairo0(client_data_json)?);
@@ -112,7 +112,7 @@ fn get_webauthn_hash_cairo0(
 }
 
 fn get_webauthn_hash_cairo1(
-    hash: felt252, signer: WebauthnSigner, signature: WebauthnSignature
+    hash: felt252, signer: WebauthnSigner, signature: WebauthnSignature,
 ) -> u256 {
     let client_data_json = encode_client_data_json(hash, signature, signer.origin);
     let client_data_hash = sha256(client_data_json.snapshot.clone()).span();
@@ -131,41 +131,7 @@ fn get_webauthn_hash(hash: felt252, signer: WebauthnSigner, signature: WebauthnS
 
 fn client_data_json_intro() -> Array<u8> {
     array![
-        '{',
-        '"',
-        't',
-        'y',
-        'p',
-        'e',
-        '"',
-        ':',
-        '"',
-        'w',
-        'e',
-        'b',
-        'a',
-        'u',
-        't',
-        'h',
-        'n',
-        '.',
-        'g',
-        'e',
-        't',
-        '"',
-        ',',
-        '"',
-        'c',
-        'h',
-        'a',
-        'l',
-        'l',
-        'e',
-        'n',
-        'g',
-        'e',
-        '"',
-        ':',
-        '"'
+        '{', '"', 't', 'y', 'p', 'e', '"', ':', '"', 'w', 'e', 'b', 'a', 'u', 't', 'h', 'n', '.',
+        'g', 'e', 't', '"', ',', '"', 'c', 'h', 'a', 'l', 'l', 'e', 'n', 'g', 'e', '"', ':', '"',
     ]
 }

--- a/argent/src/signer_storage/interface.cairo
+++ b/argent/src/signer_storage/interface.cairo
@@ -3,22 +3,22 @@ trait ISignerList<TContractState> {
     fn add_signer(ref self: TContractState, signer_to_add: felt252, last_signer: felt252);
     fn add_signers(ref self: TContractState, signers_to_add: Span<felt252>, last_signer: felt252);
     fn remove_signer(
-        ref self: TContractState, signer_to_remove: felt252, last_signer: felt252
+        ref self: TContractState, signer_to_remove: felt252, last_signer: felt252,
     ) -> felt252;
     fn remove_signers(
-        ref self: TContractState, signers_to_remove: Span<felt252>, last_signer: felt252
+        ref self: TContractState, signers_to_remove: Span<felt252>, last_signer: felt252,
     );
     fn replace_signer(
         ref self: TContractState,
         signer_to_remove: felt252,
         signer_to_add: felt252,
-        last_signer: felt252
+        last_signer: felt252,
     );
     fn load(self: @TContractState) -> (usize, felt252);
     fn is_signer_in_list(self: @TContractState, signer: felt252) -> bool;
     fn get_signers_len(self: @TContractState) -> usize;
     fn get_signers(self: @TContractState) -> Array<felt252>;
     fn is_signer_before(
-        self: @TContractState, first_signer: felt252, second_signer: felt252
+        self: @TContractState, first_signer: felt252, second_signer: felt252,
     ) -> bool;
 }

--- a/argent/src/signer_storage/signer_list.cairo
+++ b/argent/src/signer_storage/signer_list.cairo
@@ -42,7 +42,7 @@ mod signer_list_component {
 
     #[embeddable_as(SignerListInternalImpl)]
     impl InternalImpl<
-        TContractState, +HasComponent<TContractState>
+        TContractState, +HasComponent<TContractState>,
     > of ISignerList<ComponentState<TContractState>> {
         #[inline(always)]
         fn is_signer_in_list(self: @ComponentState<TContractState>, signer: felt252) -> bool {
@@ -61,7 +61,7 @@ mod signer_list_component {
 
         #[inline(always)]
         fn add_signer(
-            ref self: ComponentState<TContractState>, signer_to_add: felt252, last_signer: felt252
+            ref self: ComponentState<TContractState>, signer_to_add: felt252, last_signer: felt252,
         ) {
             assert(signer_to_add != 0, 'argent/invalid-zero-signer');
             let is_signer = self.is_signer_using_last(signer_to_add, last_signer);
@@ -73,7 +73,7 @@ mod signer_list_component {
         fn add_signers(
             ref self: ComponentState<TContractState>,
             mut signers_to_add: Span<felt252>,
-            last_signer: felt252
+            last_signer: felt252,
         ) {
             match signers_to_add.pop_front() {
                 Option::Some(signer_ref) => {
@@ -91,7 +91,7 @@ mod signer_list_component {
         fn remove_signer(
             ref self: ComponentState<TContractState>,
             signer_to_remove: felt252,
-            last_signer: felt252
+            last_signer: felt252,
         ) -> felt252 {
             let is_signer = self.is_signer_using_last(signer_to_remove, last_signer);
             assert(is_signer, 'argent/not-a-signer');
@@ -114,12 +114,12 @@ mod signer_list_component {
         fn remove_signers(
             ref self: ComponentState<TContractState>,
             mut signers_to_remove: Span<felt252>,
-            mut last_signer: felt252
+            mut last_signer: felt252,
         ) {
             loop {
                 let signer = match signers_to_remove.pop_front() {
                     Option::Some(signer) => *signer,
-                    Option::None => { break; }
+                    Option::None => { break; },
                 };
                 last_signer = self
                     .remove_signer(signer_to_remove: signer, last_signer: last_signer);
@@ -131,7 +131,7 @@ mod signer_list_component {
             ref self: ComponentState<TContractState>,
             signer_to_remove: felt252,
             signer_to_add: felt252,
-            last_signer: felt252
+            last_signer: felt252,
         ) {
             assert(signer_to_add != 0, 'argent/invalid-zero-signer');
 
@@ -190,13 +190,13 @@ mod signer_list_component {
                 }
                 signers.append(current_signer);
                 current_signer = self.signer_list.read(current_signer);
-            };
+            }
             signers
         }
 
         // Returns true if `first_signer` is before `second_signer` in the signer list.
         fn is_signer_before(
-            self: @ComponentState<TContractState>, first_signer: felt252, second_signer: felt252
+            self: @ComponentState<TContractState>, first_signer: felt252, second_signer: felt252,
         ) -> bool {
             let mut is_before: bool = false;
             let mut current_signer = first_signer;
@@ -210,7 +210,7 @@ mod signer_list_component {
                     break;
                 }
                 current_signer = next_signer;
-            };
+            }
             return is_before;
         }
     }
@@ -221,7 +221,7 @@ mod signer_list_component {
         // last signer
         #[inline(always)]
         fn is_signer_using_last(
-            self: @ComponentState<TContractState>, signer: felt252, last_signer: felt252
+            self: @ComponentState<TContractState>, signer: felt252, last_signer: felt252,
         ) -> bool {
             if signer == 0 {
                 return false;
@@ -251,7 +251,7 @@ mod signer_list_component {
         // Reverts if `signer_after` is not found
         // Cost increases with the list size
         fn find_signer_before(
-            self: @ComponentState<TContractState>, signer_after: felt252
+            self: @ComponentState<TContractState>, signer_after: felt252,
         ) -> felt252 {
             let mut current_signer = 0;
             loop {

--- a/argent/src/upgrade/interface.cairo
+++ b/argent/src/upgrade/interface.cairo
@@ -25,6 +25,6 @@ trait IUpgradableCallback<TContractState> {
     /// events The methods can only be called by the account after a call to `upgrade`
     /// @param new_implementation The class hash of the new implementation
     fn perform_upgrade(
-        ref self: TContractState, new_implementation: ClassHash, data: Span<felt252>
+        ref self: TContractState, new_implementation: ClassHash, data: Span<felt252>,
     );
 }

--- a/argent/src/upgrade/upgrade.cairo
+++ b/argent/src/upgrade/upgrade.cairo
@@ -1,6 +1,6 @@
 use argent::account::interface::SRC5_ACCOUNT_INTERFACE_ID;
-
-use starknet::{ClassHash, syscalls::replace_class_syscall};
+use starknet::ClassHash;
+use starknet::syscalls::replace_class_syscall;
 
 #[starknet::interface]
 trait IUpgradeInternal<TContractState> {
@@ -10,13 +10,14 @@ trait IUpgradeInternal<TContractState> {
 #[starknet::component]
 mod upgrade_component {
     use argent::account::interface::SRC5_ACCOUNT_INTERFACE_ID;
-    use argent::introspection::interface::{ISRC5LibraryDispatcher, ISRC5DispatcherTrait};
+    use argent::introspection::interface::{ISRC5DispatcherTrait, ISRC5LibraryDispatcher};
     use argent::upgrade::interface::{
-        IUpgradableCallback, IUpgradeable, IUpgradableCallbackLibraryDispatcher,
-        IUpgradableCallbackDispatcherTrait
+        IUpgradableCallback, IUpgradableCallbackDispatcherTrait,
+        IUpgradableCallbackLibraryDispatcher, IUpgradeable,
     };
     use argent::utils::asserts::assert_only_self;
-    use starknet::{ClassHash, syscalls::replace_class_syscall};
+    use starknet::ClassHash;
+    use starknet::syscalls::replace_class_syscall;
 
     #[storage]
     struct Storage {}
@@ -31,17 +32,17 @@ mod upgrade_component {
     /// @param new_implementation The new implementation
     #[derive(Drop, starknet::Event)]
     struct AccountUpgraded {
-        new_implementation: ClassHash
+        new_implementation: ClassHash,
     }
 
     #[embeddable_as(UpgradableImpl)]
     impl Upgradable<
-        TContractState, +HasComponent<TContractState>, +IUpgradableCallback<TContractState>
+        TContractState, +HasComponent<TContractState>, +IUpgradableCallback<TContractState>,
     > of IUpgradeable<ComponentState<TContractState>> {
         fn upgrade(
             ref self: ComponentState<TContractState>,
             new_implementation: ClassHash,
-            data: Array<felt252>
+            data: Array<felt252>,
         ) {
             assert_only_self();
             let supports_interface = ISRC5LibraryDispatcher { class_hash: new_implementation }
@@ -54,10 +55,10 @@ mod upgrade_component {
 
     #[embeddable_as(UpgradableInternalImpl)]
     impl UpgradableInternal<
-        TContractState, +HasComponent<TContractState>
+        TContractState, +HasComponent<TContractState>,
     > of super::IUpgradeInternal<ComponentState<TContractState>> {
         fn complete_upgrade(
-            ref self: ComponentState<TContractState>, new_implementation: ClassHash
+            ref self: ComponentState<TContractState>, new_implementation: ClassHash,
         ) {
             replace_class_syscall(new_implementation).expect('argent/invalid-upgrade');
             self.emit(AccountUpgraded { new_implementation });

--- a/argent/src/utils/array_store.cairo
+++ b/argent/src/utils/array_store.cairo
@@ -1,7 +1,7 @@
 /// @dev 🚨 Attention: This file has not undergone an audit and is not intended for production
 /// use. Use at your own risk. Please exercise caution and conduct your own due diligence before
 /// interacting with this contract. 🚨
-use starknet::{SyscallResult, storage_access::{Store, StorageBaseAddress}};
+use starknet::{SyscallResult, storage_access::{StorageBaseAddress, Store}};
 
 // Can store up to 255 felt252
 impl StoreFelt252Array of Store<Array<felt252>> {
@@ -10,13 +10,13 @@ impl StoreFelt252Array of Store<Array<felt252>> {
     }
 
     fn write(
-        address_domain: u32, base: StorageBaseAddress, value: Array<felt252>
+        address_domain: u32, base: StorageBaseAddress, value: Array<felt252>,
     ) -> SyscallResult<()> {
         StoreFelt252Array::write_at_offset(address_domain, base, 0, value)
     }
 
     fn read_at_offset(
-        address_domain: u32, base: StorageBaseAddress, mut offset: u8
+        address_domain: u32, base: StorageBaseAddress, mut offset: u8,
     ) -> SyscallResult<Array<felt252>> {
         let mut arr: Array<felt252> = ArrayTrait::new();
 
@@ -31,14 +31,14 @@ impl StoreFelt252Array of Store<Array<felt252>> {
             let value = Store::<felt252>::read_at_offset(address_domain, base, offset).unwrap();
             arr.append(value);
             offset += Store::<felt252>::size();
-        };
+        }
 
         // Return the array.
         Result::Ok(arr)
     }
 
     fn write_at_offset(
-        address_domain: u32, base: StorageBaseAddress, mut offset: u8, mut value: Array<felt252>
+        address_domain: u32, base: StorageBaseAddress, mut offset: u8, mut value: Array<felt252>,
     ) -> SyscallResult<()> {
         // Store the length of the array in the first storage slot.
         let len: u8 = value.len().try_into().expect('argent/array-too-large');
@@ -49,7 +49,7 @@ impl StoreFelt252Array of Store<Array<felt252>> {
         while let Option::Some(element) = value.pop_front() {
             Store::<felt252>::write_at_offset(address_domain, base, offset, element).unwrap();
             offset += Store::<felt252>::size();
-        };
+        }
         Result::Ok(())
     }
 

--- a/argent/src/utils/asserts.cairo
+++ b/argent/src/utils/asserts.cairo
@@ -1,4 +1,5 @@
-use starknet::{get_contract_address, get_caller_address, ContractAddress, account::Call};
+use starknet::account::Call;
+use starknet::{ContractAddress, get_caller_address, get_contract_address};
 
 #[inline(always)]
 fn assert_only_self() {

--- a/argent/src/utils/bytes.cairo
+++ b/argent/src/utils/bytes.cairo
@@ -24,7 +24,7 @@ impl SpanU8TryIntoFelt252 of TryInto<Span<u8>, felt252> {
             while let Option::Some(byte) = self.pop_front() {
                 let byte = (*byte).into();
                 result = (0x100 * result) + byte;
-            };
+            }
             Option::Some(result)
         } else if self.len() == 32 {
             let result: u256 = self.try_into()?;
@@ -67,38 +67,17 @@ fn u256_to_u8s(word: u256) -> Array<u8> {
     let (rest, byte_3) = integer::u128_safe_divmod(rest, 0x100);
     let (byte_1, byte_2) = integer::u128_safe_divmod(rest, 0x100);
     array![
-        byte_1.try_into().unwrap(),
-        byte_2.try_into().unwrap(),
-        byte_3.try_into().unwrap(),
-        byte_4.try_into().unwrap(),
-        byte_5.try_into().unwrap(),
-        byte_6.try_into().unwrap(),
-        byte_7.try_into().unwrap(),
-        byte_8.try_into().unwrap(),
-        byte_9.try_into().unwrap(),
-        byte_10.try_into().unwrap(),
-        byte_11.try_into().unwrap(),
-        byte_12.try_into().unwrap(),
-        byte_13.try_into().unwrap(),
-        byte_14.try_into().unwrap(),
-        byte_15.try_into().unwrap(),
-        byte_16.try_into().unwrap(),
-        byte_17.try_into().unwrap(),
-        byte_18.try_into().unwrap(),
-        byte_19.try_into().unwrap(),
-        byte_20.try_into().unwrap(),
-        byte_21.try_into().unwrap(),
-        byte_22.try_into().unwrap(),
-        byte_23.try_into().unwrap(),
-        byte_24.try_into().unwrap(),
-        byte_25.try_into().unwrap(),
-        byte_26.try_into().unwrap(),
-        byte_27.try_into().unwrap(),
-        byte_28.try_into().unwrap(),
-        byte_29.try_into().unwrap(),
-        byte_30.try_into().unwrap(),
-        byte_31.try_into().unwrap(),
-        byte_32.try_into().unwrap(),
+        byte_1.try_into().unwrap(), byte_2.try_into().unwrap(), byte_3.try_into().unwrap(),
+        byte_4.try_into().unwrap(), byte_5.try_into().unwrap(), byte_6.try_into().unwrap(),
+        byte_7.try_into().unwrap(), byte_8.try_into().unwrap(), byte_9.try_into().unwrap(),
+        byte_10.try_into().unwrap(), byte_11.try_into().unwrap(), byte_12.try_into().unwrap(),
+        byte_13.try_into().unwrap(), byte_14.try_into().unwrap(), byte_15.try_into().unwrap(),
+        byte_16.try_into().unwrap(), byte_17.try_into().unwrap(), byte_18.try_into().unwrap(),
+        byte_19.try_into().unwrap(), byte_20.try_into().unwrap(), byte_21.try_into().unwrap(),
+        byte_22.try_into().unwrap(), byte_23.try_into().unwrap(), byte_24.try_into().unwrap(),
+        byte_25.try_into().unwrap(), byte_26.try_into().unwrap(), byte_27.try_into().unwrap(),
+        byte_28.try_into().unwrap(), byte_29.try_into().unwrap(), byte_30.try_into().unwrap(),
+        byte_31.try_into().unwrap(), byte_32.try_into().unwrap(),
     ]
 }
 
@@ -111,7 +90,7 @@ impl ByteArrayExt of ByteArrayExtTrait {
         while i != len {
             output.append(self[i]);
             i += 1;
-        };
+        }
         output
     }
 }
@@ -144,7 +123,7 @@ fn u32s_to_u8s(mut words: Span<felt252>) -> Span<u8> {
         output.append(byte_2.try_into().unwrap());
         output.append(byte_3.try_into().unwrap());
         output.append(byte_4.try_into().unwrap());
-    };
+    }
     output.span()
 }
 // Takes an array of u8s and returns an array of u32s, padding the end with 0s if necessary
@@ -160,8 +139,8 @@ fn u8s_to_u32s_pad_end(mut bytes: Span<u8>) -> Array<u32> {
                 0x100_00_00 * byte1.into()
                     + 0x100_00 * byte2.into()
                     + 0x100 * byte3.into()
-                    + byte4.into()
+                    + byte4.into(),
             );
-    };
+    }
     output
 }

--- a/argent/src/utils/calls.cairo
+++ b/argent/src/utils/calls.cairo
@@ -1,5 +1,6 @@
 use argent::utils::array_ext::ArrayExtTrait;
-use starknet::{call_contract_syscall, account::Call};
+use starknet::account::Call;
+use starknet::call_contract_syscall;
 
 fn execute_multicall(mut calls: Span<Call>) -> Array<Span<felt252>> {
     let mut result = array![];
@@ -16,6 +17,6 @@ fn execute_multicall(mut calls: Span<Call>) -> Array<Span<felt252>> {
                 panic(data);
             },
         }
-    };
+    }
     result
 }

--- a/argent/src/utils/hashing.cairo
+++ b/argent/src/utils/hashing.cairo
@@ -1,5 +1,5 @@
-use argent::utils::bytes::{u8s_to_u32s_pad_end};
-use argent::utils::serialization::{serialize};
+use argent::utils::bytes::u8s_to_u32s_pad_end;
+use argent::utils::serialization::serialize;
 use starknet::{class_hash_const, library_call_syscall};
 
 // Hashes two felts using poseidon
@@ -13,7 +13,7 @@ fn poseidon_2(a: felt252, b: felt252) -> felt252 {
 fn sha256_cairo0(message: Span<u8>) -> Option<Span<felt252>> {
     let calldata = serialize(@(u8s_to_u32s_pad_end(message), message.len()));
     let class_hash = class_hash_const::<
-        0x04dacc042b398d6f385a87e7dd65d2bcb3270bb71c4b34857b3c658c7f52cf6d
+        0x04dacc042b398d6f385a87e7dd65d2bcb3270bb71c4b34857b3c658c7f52cf6d,
     >();
     if let Result::Ok(output) =
         library_call_syscall(class_hash, selector!("sha256_cairo0"), calldata.span()) {

--- a/argent/src/utils/multicall.cairo
+++ b/argent/src/utils/multicall.cairo
@@ -8,7 +8,8 @@ trait IMulticall<TContractState> {
 #[starknet::contract]
 mod Multicall {
     use argent::utils::calls::execute_multicall;
-    use starknet::{info::get_block_number, account::Call};
+    use starknet::account::Call;
+    use starknet::info::get_block_number;
 
     #[storage]
     struct Storage {}

--- a/argent/src/utils/serialization.cairo
+++ b/argent/src/utils/serialization.cairo
@@ -1,7 +1,7 @@
 // Tries to deserialize the given data into.
 // The data must only contain the returned value and nothing else
 fn full_deserialize<E, impl ESerde: Serde<E>, impl EDrop: Drop<E>>(
-    mut data: Span<felt252>
+    mut data: Span<felt252>,
 ) -> Option<E> {
     let parsed_value: E = ESerde::deserialize(ref data)?;
     if data.is_empty() {

--- a/argent/src/utils/transaction_version.cairo
+++ b/argent/src/utils/transaction_version.cairo
@@ -1,14 +1,17 @@
-use starknet::{SyscallResultTrait, get_execution_info, get_tx_info, get_caller_address};
+use starknet::{SyscallResultTrait, get_caller_address, get_execution_info, get_tx_info};
 
 const TX_V1: felt252 = 1; // INVOKE
-const TX_V1_ESTIMATE: felt252 =
-    consteval_int!(0x100000000000000000000000000000000 + 1); // 2**128 + TX_V1
+const TX_V1_ESTIMATE: felt252 = consteval_int!(
+    0x100000000000000000000000000000000 + 1,
+); // 2**128 + TX_V1
 const TX_V2: felt252 = 2; // DECLARE           
-const TX_V2_ESTIMATE: felt252 =
-    consteval_int!(0x100000000000000000000000000000000 + 2); // 2**128 + TX_V2
+const TX_V2_ESTIMATE: felt252 = consteval_int!(
+    0x100000000000000000000000000000000 + 2,
+); // 2**128 + TX_V2
 const TX_V3: felt252 = 3;
-const TX_V3_ESTIMATE: felt252 =
-    consteval_int!(0x100000000000000000000000000000000 + 3); // 2**128 + TX_V3
+const TX_V3_ESTIMATE: felt252 = consteval_int!(
+    0x100000000000000000000000000000000 + 3,
+); // 2**128 + TX_V3
 
 const DA_MODE_L1: u32 = 0;
 const DA_MODE_L2: u32 = 1;
@@ -20,7 +23,7 @@ fn assert_correct_invoke_version(tx_version: felt252) {
             || tx_version == TX_V1
             || tx_version == TX_V3_ESTIMATE
             || tx_version == TX_V1_ESTIMATE,
-        'argent/invalid-tx-version'
+        'argent/invalid-tx-version',
     )
 }
 
@@ -31,7 +34,7 @@ fn assert_correct_deploy_account_version(tx_version: felt252) {
             || tx_version == TX_V1
             || tx_version == TX_V3_ESTIMATE
             || tx_version == TX_V1_ESTIMATE,
-        'argent/invalid-deploy-account-v'
+        'argent/invalid-deploy-account-v',
     )
 }
 
@@ -42,7 +45,7 @@ fn assert_correct_declare_version(tx_version: felt252) {
             || tx_version == TX_V2
             || tx_version == TX_V3_ESTIMATE
             || tx_version == TX_V2_ESTIMATE,
-        'argent/invalid-declare-version'
+        'argent/invalid-declare-version',
     )
 }
 

--- a/sncast/script.sh
+++ b/sncast/script.sh
@@ -3,56 +3,69 @@
 # Declare Contracts
 echo "Declaring contracts..."
 
-OUTPUT1=$(sncast declare -c FossilClient --fee-token eth)
-FOSSIL_CLASS_HASH=$(echo "$OUTPUT1" | awk '/class_hash:/ {print $2}')
-###   FOSSIL_CLASS_HASH=0x711b785a4c9741c731b01a7487e3aaaf73acb2d9da9f68704a06a39baa4f1b6
-echo "Fossil class hash: $FOSSIL_CLASS_HASH"
+# OUTPUT1=$(sncast declare -c FossilClient --fee-token eth)
+# FOSSIL_CLASS_HASH=$(echo "$OUTPUT1" | awk '/class_hash:/ {print $2}')
+# ###   FOSSIL_CLASS_HASH=0x711b785a4c9741c731b01a7487e3aaaf73acb2d9da9f68704a06a39baa4f1b6
+# echo "Fossil class hash: $FOSSIL_CLASS_HASH"
 
 OUTPUT2=$(sncast declare -c OptionRound --fee-token eth)
 OPTION_ROUND_CLASS_HASH=$(echo "$OUTPUT2" | awk '/class_hash:/ {print $2}')
-###   OPTION_ROUND_CLASS_HASH=0x378211be15fa10df3a5d70e92bfd1bca0752a0196ea0bfcd5b3131491a1305
 echo "Option round class hash: $OPTION_ROUND_CLASS_HASH"
 
 OUTPUT3=$(sncast declare -c Vault --fee-token eth)
 VAULT_CLASS_HASH=$(echo "$OUTPUT3" | awk '/class_hash:/ {print $2}')
-### VAULT_CLASS_HASH=0x51653f39500cfb021b791c3bf9f2b2f1e294a862c8824be21f3b44a0ee40449
 echo "Vault class hash: $VAULT_CLASS_HASH"
 
 # Deploy contracts
 echo "Deploying contracts..."
 
-ETH_ADDRESS=0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
-echo "ETH address: $ETH_ADDRESS"
+#OUTPUT4=$(sncast deploy --fee-token eth --class-hash $FOSSIL_CLASS_HASH --constructor-calldata $FOSSIL_PROCESSOR)
+#FOSSIL_CONTRACT_ADDRESS=$(echo "$OUTPUT4" | awk '/contract_address:/ {print $2}')
+####   FOSSIL_CONTRACT_ADDRESS=0x0239664d7e16f82ad369eed526150fedfbb8c02d5ea374d826228d8f8ae3d91c
+#echo "Fossil Client address: $FOSSIL_CONTRACT_ADDRESS"
 
+# Vault Args
+
+# TODO: update .env to use `PITCHLAKE_VERIFIER`
 FOSSIL_PROCESSOR=$(grep '^FOSSIL_PROCESSOR=' .env | cut -d '=' -f2 | tr -d '"')
 echo "Fossil processor address: $FOSSIL_PROCESSOR"
 
-OUTPUT4=$(sncast deploy --fee-token eth --class-hash $FOSSIL_CLASS_HASH --constructor-calldata $FOSSIL_PROCESSOR)
-FOSSIL_CONTRACT_ADDRESS=$(echo "$OUTPUT4" | awk '/contract_address:/ {print $2}')
-###   FOSSIL_CONTRACT_ADDRESS=0x0239664d7e16f82ad369eed526150fedfbb8c02d5ea374d826228d8f8ae3d91c
-echo "Fossil Client address: $FOSSIL_CONTRACT_ADDRESS"
+ETH_ADDRESS=0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7
+echo "ETH address: $ETH_ADDRESS"
+
+K=0
+ALPHA=2500
+PROGRAM_ID=0x50495443485f4c414b455f5631 # PITCH_LAKE_V1
+PROVING_DELAY=0                         # Can settlement round at settlement date + 0
 
 # 12 minute vault
 ROUND_TRANSITION_DURATION1=180 # 3 min
 AUCTION_DURATION1=180          # 3 min
 ROUND_DURATION1=720            # 12 min
-sleep 60
-OUTPUT5=$(sncast deploy --fee-token eth --class-hash $VAULT_CLASS_HASH --constructor-calldata $FOSSIL_CONTRACT_ADDRESS $ETH_ADDRESS $OPTION_ROUND_CLASS_HASH 5000 0 $ROUND_TRANSITION_DURATION1 $AUCTION_DURATION1 $ROUND_DURATION1)
-VAULT_CONTRACT_ADDRESS=$(echo "$OUTPUT5" | awk '/contract_address:/ {print $2}')
-echo "(12 minute) Vault address: $VAULT_CONTRACT_ADDRESS"
 # 3 hour vault
 ROUND_TRANSITION_DURATION2=1800 # 30 min
 AUCTION_DURATION2=1800          # 30 min
 ROUND_DURATION2=10800           # 3 hour
-sleep 60
+# Rapid vault (5.5 min)
+ROUND_TRANSITION_DURATION3=90 # 1.5 min
+AUCTION_DURATION3=90          # 1.5 min
+ROUND_DURATION3=90            # 1.5 min
+
+# 1 month vault
+#sleep 60
+#ROUND_TRANSITION_DURATION3=10800 # 3 hours
+#AUCTION_DURATION3=10800          # 3 hours
+#ROUND_DURATION3=2592000          # 1 month
+
+OUTPUT5=$(sncast deploy --fee-token eth --class-hash $VAULT_CLASS_HASH --constructor-calldata $FOSSIL_CONTRACT_ADDRESS $ETH_ADDRESS $OPTION_ROUND_CLASS_HASH 5000 0 $ROUND_TRANSITION_DURATION1 $AUCTION_DURATION1 $ROUND_DURATION1)
+VAULT_CONTRACT_ADDRESS=$(echo "$OUTPUT5" | awk '/contract_address:/ {print $2}')
+echo "(12 minute) Vault address: $VAULT_CONTRACT_ADDRESS"
+
+sleep 25
 OUTPUT5_2=$(sncast deploy --fee-token eth --class-hash $VAULT_CLASS_HASH --constructor-calldata $FOSSIL_CONTRACT_ADDRESS $ETH_ADDRESS $OPTION_ROUND_CLASS_HASH 2500 0 $ROUND_TRANSITION_DURATION2 $AUCTION_DURATION2 $ROUND_DURATION2)
 VAULT_CONTRACT_ADDRESS2=$(echo "$OUTPUT5_2" | awk '/contract_address:/ {print $2}')
 echo "(15 minute) Vault address: $VAULT_CONTRACT_ADDRESS2"
-# 1 month vault
-sleep 60
-ROUND_TRANSITION_DURATION3=10800 # 3 hours
-AUCTION_DURATION3=10800          # 3 hours
-ROUND_DURATION3=2592000          # 1 month
+
 OUTPUT5_3=$(sncast deploy --fee-token eth --class-hash $VAULT_CLASS_HASH --constructor-calldata $FOSSIL_CONTRACT_ADDRESS $ETH_ADDRESS $OPTION_ROUND_CLASS_HASH 1250 0 $ROUND_TRANSITION_DURATION3 $AUCTION_DURATION3 $ROUND_DURATION3)
 VAULT_CONTRACT_ADDRESS3=$(echo "$OUTPUT5_3" | awk '/contract_address:/ {print $2}')
 echo "(30 day) Vault address: $VAULT_CONTRACT_ADDRESS3"

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -1,22 +1,22 @@
-mod types;
+pub mod types;
 
-mod library {
-    mod eth;
-    mod red_black_tree;
-    mod utils;
-    mod pricing_utils;
-    mod constants;
+pub mod library {
+    pub mod constants;
+    pub mod eth;
+    pub mod pricing_utils;
+    pub mod red_black_tree;
+    pub mod utils;
 }
 
-mod vault {
-    mod interface;
-    mod contract;
+pub mod vault {
+    pub mod contract;
+    pub mod interface;
 }
 
 mod option_round {
-    mod interface;
-    mod contract;
+    pub mod contract;
+    pub mod interface;
 }
 
 #[cfg(test)]
-mod tests;
+pub mod tests;

--- a/src/library/constants.cairo
+++ b/src/library/constants.cairo
@@ -11,6 +11,6 @@ const BPS_felt252: felt252 = 10_000;
 // The identifier of the program Fossil will run
 const PROGRAM_ID: felt252 = 'PITCH_LAKE_V1';
 
-// Vaults accept data from Fossil if the timestamp is within this tolerance
-const REQUEST_TOLERANCE: u64 = 1 * HOUR;
+// The time it takes for Fossil to be able to prove the latest block header
+const PROVING_DELAY: u64 = 10 * MINUTE;
 

--- a/src/library/constants.cairo
+++ b/src/library/constants.cairo
@@ -1,7 +1,7 @@
-const MINUTE: u64 = 60;
-const HOUR: u64 = 60 * MINUTE;
-const DAY: u64 = 24 * HOUR;
-const BPS_u128: u128 = 10_000;
-const BPS_i128: i128 = 10_000;
-const BPS_u256: u256 = 10_000;
-const BPS_felt252: felt252 = 10_000;
+pub const MINUTE: u64 = 60;
+pub const HOUR: u64 = 60 * MINUTE;
+pub const DAY: u64 = 24 * HOUR;
+pub const BPS_u128: u128 = 10_000;
+pub const BPS_i128: i128 = 10_000;
+pub const BPS_u256: u256 = 10_000;
+pub const BPS_felt252: felt252 = 10_000;

--- a/src/library/constants.cairo
+++ b/src/library/constants.cairo
@@ -5,12 +5,3 @@ const BPS_u128: u128 = 10_000;
 const BPS_i128: i128 = 10_000;
 const BPS_u256: u256 = 10_000;
 const BPS_felt252: felt252 = 10_000;
-
-/// FOSSIL CLIENT ///
-
-// The identifier of the program Fossil will run
-const PROGRAM_ID: felt252 = 'PITCH_LAKE_V1';
-
-// The time it takes for Fossil to be able to prove the latest block header
-const PROVING_DELAY: u64 = 10 * MINUTE;
-

--- a/src/library/eth.cairo
+++ b/src/library/eth.cairo
@@ -6,9 +6,9 @@
 // deploy contracts at different addresses like in governance
 
 #[starknet::contract]
-mod Eth {
+pub mod Eth {
+    use openzeppelin_token::erc20::{DefaultConfig, ERC20Component, ERC20HooksEmptyImpl};
     use starknet::ContractAddress;
-    use openzeppelin_token::erc20::{ERC20Component, ERC20HooksEmptyImpl};
 
     component!(path: ERC20Component, storage: erc20, event: ERC20Event);
     // Exposes snake_case & CamelCase entry points
@@ -20,14 +20,14 @@ mod Eth {
     #[storage]
     struct Storage {
         #[substorage(v0)]
-        pub erc20: ERC20Component::Storage
+        pub erc20: ERC20Component::Storage,
     }
 
     #[event]
     #[derive(Drop, starknet::Event)]
     enum Event {
         #[flat]
-        ERC20Event: ERC20Component::Event
+        ERC20Event: ERC20Component::Event,
     }
 
     #[constructor]

--- a/src/library/pricing_utils.cairo
+++ b/src/library/pricing_utils.cairo
@@ -1,15 +1,14 @@
-use core::num::traits::Zero;
+use pitch_lake::library::constants::{BPS_i128, BPS_u256};
 use pitch_lake::library::utils::min;
-use pitch_lake::library::constants::{BPS_i128, BPS_felt252, BPS_u256, BPS_u128};
 
 // Calculate the maximum payout for a single option
-fn max_payout_per_option(strike_price: u256, cap_level: u128) -> u256 {
+pub fn max_payout_per_option(strike_price: u256, cap_level: u128) -> u256 {
     (strike_price * cap_level.into()) / BPS_u256
 }
 
 // Calculate the actual payout for a single option
-fn calculate_payout_per_option(
-    strike_price: u256, cap_level: u128, settlement_price: u256
+pub fn calculate_payout_per_option(
+    strike_price: u256, cap_level: u128, settlement_price: u256,
 ) -> u256 {
     if (settlement_price <= strike_price) {
         0
@@ -22,8 +21,8 @@ fn calculate_payout_per_option(
 }
 
 // Calculate the total number of options available to sell in an auction
-fn calculate_total_options_available(
-    starting_liquidity: u256, strike_price: u256, cap_level: u128
+pub fn calculate_total_options_available(
+    starting_liquidity: u256, strike_price: u256, cap_level: u128,
 ) -> u256 {
     let capped = max_payout_per_option(strike_price, cap_level);
     match capped == 0 {
@@ -31,7 +30,7 @@ fn calculate_total_options_available(
         true => 0,
         // @dev Else the number of options available is the starting liquidity divided by
         // the capped amount
-        false => starting_liquidity / capped
+        false => starting_liquidity / capped,
     }
 }
 
@@ -41,7 +40,7 @@ fn calculate_total_options_available(
 // in the event of a black swan event, LPs are willing to lose at most 25% of their capital)
 // @param k: strike level in BPS (e.g., 0 for ATM, -3333 for -33.33%)
 // @param max_returns: maximum returns in BPS (e.g., 12345 for 123.45%)
-fn calculate_cap_level(alpha: u128, k: i128, max_returns: u128) -> u128 {
+pub fn calculate_cap_level(alpha: u128, k: i128, max_returns: u128) -> u128 {
     let max_returns_minus_k: i128 = (max_returns.try_into().unwrap()) - k;
     let k_plus_one = BPS_i128 + k;
 
@@ -67,7 +66,7 @@ fn calculate_cap_level(alpha: u128, k: i128, max_returns: u128) -> u128 {
 // @param k: the strike level
 // @note The minimum strike_level of -9999 translates to a strike price -99.99% the current twap
 // (-10_000 would mean a strike price == 0)
-fn calculate_strike_price(k: i128, twap: u256) -> u256 {
+pub fn calculate_strike_price(k: i128, twap: u256) -> u256 {
     let k_plus_1: i128 = k + BPS_i128;
     assert(k_plus_1 > 0, 'Strike price must be > 0');
 

--- a/src/library/utils.cairo
+++ b/src/library/utils.cairo
@@ -3,25 +3,25 @@ use pitch_lake::vault::interface::JobRequest;
 
 pub const VALUES_NOT_IN_RANGE: felt252 = 'Values not in range';
 
-fn assert_equal_in_range<T, +PartialOrd<T>, +Add<T>, +Sub<T>, +Drop<T>, +Copy<T>>(
-    a: T, b: T, range: T
+pub fn assert_equal_in_range<T, +PartialOrd<T>, +Add<T>, +Sub<T>, +Drop<T>, +Copy<T>>(
+    a: T, b: T, range: T,
 ) {
     assert(a >= b - range && a <= b + range, VALUES_NOT_IN_RANGE);
 }
 
 // @dev Returns the minimum of a and b
-fn min<T, +PartialEq<T>, +PartialOrd<T>, +Drop<T>, +Copy<T>>(a: T, b: T) -> T {
+pub fn min<T, +PartialEq<T>, +PartialOrd<T>, +Drop<T>, +Copy<T>>(a: T, b: T) -> T {
     match a < b {
         true => a,
-        false => b
+        false => b,
     }
 }
 
 // @dev Returns the maximum of a and b
-fn max<T, +PartialEq<T>, +PartialOrd<T>, +Drop<T>, +Copy<T>>(a: T, b: T) -> T {
+pub fn max<T, +PartialEq<T>, +PartialOrd<T>, +Drop<T>, +Copy<T>>(a: T, b: T) -> T {
     match a < b {
         true => b,
-        false => a
+        false => a,
     }
 }
 
@@ -39,9 +39,8 @@ fn pow(base: u256, exp: u8) -> u256 {
 }
 
 // @dev Serialize the job request and hash it to create the its ID
-fn generate_request_id(request: JobRequest) -> felt252 {
+pub fn generate_request_id(request: JobRequest) -> felt252 {
     let mut serialized: Array<felt252> = Default::default();
     request.serialize(ref serialized);
     poseidon_hash_span(serialized.span())
 }
-

--- a/src/option_round/interface.cairo
+++ b/src/option_round/interface.cairo
@@ -1,37 +1,37 @@
-use starknet::{ContractAddress, StorePacking};
-use pitch_lake::types::{Bid};
+use pitch_lake::types::Bid;
+use starknet::ContractAddress;
 
 // An enum for each state an option round can be in
 #[derive(Default, Copy, Drop, Serde, PartialEq, starknet::Store)]
-enum OptionRoundState {
+pub enum OptionRoundState {
     #[default]
     Open, // Accepting deposits, waiting for auction to start
     Auctioning, // Auction is on going, accepting bids
     Running, // Auction has ended, waiting for option round expiry date to settle
-    Settled, // Option round has settled, remaining liquidity has rolled over to the next round
+    Settled // Option round has settled, remaining liquidity has rolled over to the next round
 }
 
 // @dev Option pricing data, needed for a round's auction to start
 #[derive(Default, PartialEq, Copy, Drop, Serde, starknet::Store)]
-struct PricingData {
-    strike_price: u256,
-    cap_level: u128,
-    reserve_price: u256,
+pub struct PricingData {
+    pub strike_price: u256,
+    pub cap_level: u128,
+    pub reserve_price: u256,
 }
 
 #[derive(Drop, Serde)]
-struct ConstructorArgs {
-    vault_address: ContractAddress,
-    round_id: u64,
-    pricing_data: PricingData,
-    round_transition_duration: u64,
-    auction_duration: u64,
-    round_duration: u64,
+pub struct ConstructorArgs {
+    pub vault_address: ContractAddress,
+    pub round_id: u64,
+    pub pricing_data: PricingData,
+    pub round_transition_duration: u64,
+    pub auction_duration: u64,
+    pub round_duration: u64,
 }
 
 // The interface for an option round contract
 #[starknet::interface]
-trait IOptionRound<TContractState> {
+pub trait IOptionRound<TContractState> {
     /// Reads ///
 
     /// Round details

--- a/src/tests.cairo
+++ b/src/tests.cairo
@@ -1,62 +1,62 @@
 #[cfg(test)]
-mod pitchlake_verifier {
-    mod verifier_tests;
+pub mod pitchlake_verifier {
+    pub mod verifier_tests;
 }
 
 #[cfg(test)]
-mod vault {
-    mod state_transition {
-        mod auction_end_tests;
-        mod auction_start_tests;
-        mod option_settle_tests;
+pub mod vault {
+    pub mod state_transition {
+        pub mod auction_end_tests;
+        pub mod auction_start_tests;
+        pub mod option_settle_tests;
     }
 
-    mod liquidity_providers {
-        mod deposit_tests;
-        mod withdraw_tests;
-        mod withdrawal_queue_tests;
-    }
-}
-
-#[cfg(test)]
-mod option_round {
-    mod option_buyers {
-        mod bidding_tests;
-        mod exercise_options_tests;
-        mod refunding_bids_tests;
-        mod update_bids_tests;
-        mod tokenizing_options_tests;
-    }
-    mod rb_tree {
-        mod rb_tree_tests;
-        mod rb_tree_mock_contract;
-        mod rb_tree_stress_tests;
-    }
-    mod state_transition {
-        mod auction_end {
-            mod auction_end_tests;
-            mod refundable_bids_tests;
-            mod clearing_price_tests;
-            mod option_distribution_tests;
-            mod premium_earned_tests;
-            mod unsold_liquidity_tests;
-        }
-        mod auction_start {
-            mod auction_start_tests;
-        }
-        mod option_settle {
-            mod calculated_payout_tests;
-            mod option_settle_tests;
-        }
-        mod caller_is_not_vault_tests;
-        mod fulfill_request_tests;
+    pub mod liquidity_providers {
+        pub mod deposit_tests;
+        pub mod withdraw_tests;
+        pub mod withdrawal_queue_tests;
     }
 }
 
 #[cfg(test)]
-mod deployment {
-    mod constructor_tests;
-    mod initializing_option_round_params_tests;
+pub mod option_round {
+    pub mod option_buyers {
+        pub mod bidding_tests;
+        pub mod exercise_options_tests;
+        pub mod refunding_bids_tests;
+        pub mod tokenizing_options_tests;
+        pub mod update_bids_tests;
+    }
+    pub mod rb_tree {
+        pub mod rb_tree_mock_contract;
+        pub mod rb_tree_stress_tests;
+        pub mod rb_tree_tests;
+    }
+    pub mod state_transition {
+        pub mod auction_end {
+            pub mod auction_end_tests;
+            pub mod clearing_price_tests;
+            pub mod option_distribution_tests;
+            pub mod premium_earned_tests;
+            pub mod refundable_bids_tests;
+            pub mod unsold_liquidity_tests;
+        }
+        pub mod auction_start {
+            pub mod auction_start_tests;
+        }
+        pub mod option_settle {
+            pub mod calculated_payout_tests;
+            pub mod option_settle_tests;
+        }
+        pub mod caller_is_not_vault_tests;
+        pub mod fulfill_request_tests;
+    }
+}
+
+#[cfg(test)]
+pub mod deployment {
+    pub mod constructor_tests;
+    pub mod initializing_option_round_params_tests;
 }
 
 #[cfg(test)]
@@ -65,23 +65,22 @@ mod misc {
 }
 
 #[cfg(test)]
-mod utils {
-    mod facades {
-        mod vault_facade;
-        mod option_round_facade;
-        mod sanity_checks;
+pub mod utils {
+    pub mod facades {
+        pub mod option_round_facade;
+        pub mod sanity_checks;
+        pub mod vault_facade;
     }
 
-    mod helpers {
-        mod accelerators;
-        mod event_helpers;
-        mod general_helpers;
-        mod setup;
+    pub mod helpers {
+        pub mod accelerators;
+        pub mod event_helpers;
+        pub mod general_helpers;
+        pub mod setup;
     }
 
-    mod lib {
-        mod test_accounts;
-        mod variables;
+    pub mod lib {
+        pub mod test_accounts;
+        pub mod variables;
     }
 }
-

--- a/src/tests/deployment/constructor_tests.cairo
+++ b/src/tests/deployment/constructor_tests.cairo
@@ -1,38 +1,39 @@
 //use openzeppelin_token::erc20::interface::{ERC20ABIDispatcherTrait,};
-use starknet::ContractAddress;
 use pitch_lake::{
     library::eth::Eth,
     vault::{
         contract::Vault,
         interface::{
-            IVaultDispatcher, IVaultSafeDispatcher, IVaultDispatcherTrait, IVaultSafeDispatcherTrait
-        }
+            IVaultDispatcher, IVaultDispatcherTrait, IVaultSafeDispatcher,
+            IVaultSafeDispatcherTrait,
+        },
     },
     option_round::{
         //contract::{OptionRound,},
-        interface::{OptionRoundState, IOptionRoundDispatcher, IOptionRoundDispatcherTrait,},
+        interface::{IOptionRoundDispatcher, IOptionRoundDispatcherTrait, OptionRoundState},
     },
     tests::{
         utils::{
             helpers::{
-                setup::{setup_facade, PROVING_DELAY, PROGRAM_ID},
                 event_helpers::{
-                    assert_event_auction_start, assert_event_auction_end, assert_event_option_settle
-                }
+                    assert_event_auction_end, assert_event_auction_start,
+                    assert_event_option_settle,
+                },
+                setup::{PROGRAM_ID, PROVING_DELAY, setup_facade},
             },
             facades::{
-                vault_facade::VaultFacadeTrait,
                 option_round_facade::{OptionRoundFacade, OptionRoundFacadeTrait},
+                vault_facade::VaultFacadeTrait,
             },
-            lib::{variables::{decimals}, //            test_accounts::{
+            lib::{variables::{decimals} //            test_accounts::{
             //                liquidity_provider_1, liquidity_provider_2, option_bidder_buyer_1,
             //                option_bidder_buyer_2
             //            },
-            }
+            },
         },
     },
 };
-use debug::PrintTrait;
+use starknet::ContractAddress;
 
 
 /// Constructor Tests ///
@@ -82,7 +83,7 @@ fn test_option_round_constructor() {
         (
             vault.get_auction_run_time(),
             vault.get_option_run_time(),
-            vault.get_round_transition_period()
+            vault.get_round_transition_period(),
         )
     };
 

--- a/src/tests/deployment/constructor_tests.cairo
+++ b/src/tests/deployment/constructor_tests.cairo
@@ -15,7 +15,7 @@ use pitch_lake::{
     tests::{
         utils::{
             helpers::{
-                setup::{setup_facade},
+                setup::{setup_facade, PROVING_DELAY, PROGRAM_ID},
                 event_helpers::{
                     assert_event_auction_start, assert_event_auction_end, assert_event_option_settle
                 }
@@ -53,6 +53,10 @@ fn test_vault_constructor() {
     assert(current_round.get_state() == OptionRoundState::Open, 'next round should be Open');
     // Test vault constructor values
     assert(vault.get_eth_address() == eth.contract_address, 'eth address incorrect');
+    // Test program id
+    assert(vault.get_program_id() == PROGRAM_ID, 'program id incorrect');
+    // Test proving delay
+    assert(vault.get_proving_delay() == PROVING_DELAY, 'proving delay incorrect');
 }
 
 
@@ -73,7 +77,7 @@ fn test_option_round_constructor() {
     assert_eq!(current_round.get_round_id(), 1);
 
     // Get time params
-    let now = starknet::get_block_timestamp();
+    let deployment_timestamp = current_round.get_deployment_date();
     let (auction_run_time, option_run_time, round_transition_period) = {
         (
             vault.get_auction_run_time(),
@@ -82,7 +86,7 @@ fn test_option_round_constructor() {
         )
     };
 
-    let auction_start_date = now + round_transition_period;
+    let auction_start_date = deployment_timestamp + round_transition_period;
     let auction_end_date = auction_start_date + auction_run_time;
     let option_settlement_date = auction_end_date + option_run_time;
 

--- a/src/tests/deployment/initializing_option_round_params_tests.cairo
+++ b/src/tests/deployment/initializing_option_round_params_tests.cairo
@@ -1,37 +1,26 @@
-use starknet::{
-    ClassHash, ContractAddress, contract_address_const, deploy_syscall,
-    Felt252TryIntoContractAddress, get_contract_address, get_block_timestamp,
-    testing::{set_block_timestamp, set_contract_address}, contract_address::ContractAddressZeroable
-};
 use openzeppelin_token::erc20::interface::ERC20ABIDispatcherTrait;
-
-use pitch_lake::{
-    vault::{contract::Vault, interface::{IVaultDispatcher, IVaultDispatcherTrait},},
-    option_round::interface::{IOptionRoundDispatcher, IOptionRoundDispatcherTrait},
-    tests::{
-        utils::{
-            helpers::{
-                setup::{deploy_eth, decimals, setup_facade, setup_facade_custom, deploy_vault,},
-                event_helpers::{pop_log, assert_no_events_left},
-                accelerators::{
-                    accelerate_to_auctioning, accelerate_to_running, accelerate_to_settled
-                }
-            },
-            lib::test_accounts::{
-                liquidity_provider_1, liquidity_provider_2, option_bidder_buyer_1,
-                option_bidder_buyer_2, option_bidder_buyer_3, option_bidder_buyer_4, bystander,
-            },
-            facades::{
-                option_round_facade::{
-                    OptionRoundFacade, OptionRoundFacadeTrait, OptionRoundFacadeImpl
-                },
-                vault_facade::{VaultFacade, VaultFacadeTrait},
-            },
-        },
-    },
-    library::pricing_utils::calculate_strike_price
+use pitch_lake::library::pricing_utils::calculate_strike_price;
+use pitch_lake::option_round::interface::{IOptionRoundDispatcher, IOptionRoundDispatcherTrait};
+use pitch_lake::tests::utils::facades::option_round_facade::{
+    OptionRoundFacade, OptionRoundFacadeImpl, OptionRoundFacadeTrait,
 };
-use debug::PrintTrait;
+use pitch_lake::tests::utils::facades::vault_facade::{VaultFacade, VaultFacadeTrait};
+use pitch_lake::tests::utils::helpers::accelerators::{
+    accelerate_to_auctioning, accelerate_to_running, accelerate_to_settled,
+};
+use pitch_lake::tests::utils::helpers::event_helpers::{assert_no_events_left, pop_log};
+use pitch_lake::tests::utils::helpers::setup::{
+    deploy_eth, deploy_vault, setup_facade, setup_facade_custom,
+};
+use pitch_lake::tests::utils::lib::test_accounts::{
+    bystander, liquidity_provider_1, liquidity_provider_2, option_bidder_buyer_1,
+    option_bidder_buyer_2, option_bidder_buyer_3, option_bidder_buyer_4,
+};
+use pitch_lake::vault::contract::Vault;
+use pitch_lake::vault::interface::{IVaultDispatcher, IVaultDispatcherTrait};
+use starknet::syscalls::deploy_syscall;
+use starknet::testing::{set_block_timestamp, set_contract_address};
+use starknet::{ClassHash, ContractAddress, get_block_timestamp, get_contract_address};
 
 
 fn to_gwei(amount: u256) -> u256 {

--- a/src/tests/option_round/option_buyers/exercise_options_tests.cairo
+++ b/src/tests/option_round/option_buyers/exercise_options_tests.cairo
@@ -1,35 +1,18 @@
 use core::traits::Into;
-use starknet::testing::{set_block_timestamp, set_contract_address};
-use openzeppelin_token::erc20::interface::{ERC20ABIDispatcherTrait,};
-use pitch_lake::{
-    option_round::contract::OptionRound::Errors,
-    tests::{
-        utils::{
-            helpers::{
-                general_helpers::{create_array_linear, get_erc20_balance, get_erc20_balances},
-                event_helpers::{
-                    assert_event_transfer, assert_event_vault_withdrawal,
-                    assert_event_options_exercised, clear_event_logs,
-                },
-                setup::{setup_facade},
-                accelerators::{
-                    accelerate_to_auctioning, accelerate_to_running, accelerate_to_settled,
-                    accelerate_to_running_custom,
-                },
-            },
-            lib::{
-                test_accounts::{
-                    liquidity_provider_1, option_bidder_buyer_1, option_bidder_buyer_2,
-                    option_bidder_buyer_3, option_bidders_get
-                },
-                variables::decimals,
-            },
-            facades::{
-                vault_facade::{VaultFacade, VaultFacadeTrait},
-                option_round_facade::{OptionRoundFacade, OptionRoundFacadeTrait},
-            },
-        },
-    }
+use pitch_lake::option_round::contract::OptionRound::Errors;
+use pitch_lake::tests::utils::facades::option_round_facade::OptionRoundFacadeTrait;
+use pitch_lake::tests::utils::facades::vault_facade::VaultFacadeTrait;
+use pitch_lake::tests::utils::helpers::accelerators::{
+    accelerate_to_auctioning, accelerate_to_running, accelerate_to_running_custom,
+    accelerate_to_settled,
+};
+use pitch_lake::tests::utils::helpers::event_helpers::{
+    assert_event_options_exercised, clear_event_logs,
+};
+use pitch_lake::tests::utils::helpers::general_helpers::{create_array_linear, get_erc20_balance};
+use pitch_lake::tests::utils::helpers::setup::setup_facade;
+use pitch_lake::tests::utils::lib::test_accounts::{
+    option_bidder_buyer_1, option_bidder_buyer_2, option_bidders_get,
 };
 
 
@@ -92,11 +75,11 @@ fn test_exercise_options_events() {
             clear_event_logs(array![current_round.contract_address()]);
             let payout_amount = current_round.exercise_options(*ob);
             assert_event_options_exercised(
-                current_round.contract_address(), *ob, bid_count, 0_u256, payout_amount
+                current_round.contract_address(), *ob, bid_count, 0_u256, payout_amount,
             );
         },
-        Option::None => {}
-    };
+        Option::None => {},
+    }
     // The rest of the OBs exercise all of their options which are mintable
     loop {
         match option_bidders.pop_front() {
@@ -104,10 +87,10 @@ fn test_exercise_options_events() {
                 clear_event_logs(array![current_round.contract_address()]);
                 let payout_amount = current_round.exercise_options(*ob);
                 assert_event_options_exercised(
-                    current_round.contract_address(), *ob, bid_count, bid_count, payout_amount
+                    current_round.contract_address(), *ob, bid_count, bid_count, payout_amount,
                 );
             },
-            Option::None => { break (); }
+            Option::None => { break (); },
         }
     };
 }
@@ -133,7 +116,7 @@ fn test_exercise_options_eth_transfer() {
 
     // Eth balance before
     let round_balance_before = get_erc20_balance(
-        eth.contract_address, current_round.contract_address()
+        eth.contract_address, current_round.contract_address(),
     );
     loop {
         match option_bidders.pop_front() {
@@ -144,11 +127,11 @@ fn test_exercise_options_eth_transfer() {
                 let lp_balance_after = get_erc20_balance(eth.contract_address, *ob);
                 assert_eq!(lp_balance_after, lp_balance_before + payout_amount);
             },
-            Option::None => { break (); }
+            Option::None => { break (); },
         }
-    };
+    }
     let round_balance_after = get_erc20_balance(
-        eth.contract_address, current_round.contract_address()
+        eth.contract_address, current_round.contract_address(),
     );
     assert(round_balance_after == round_balance_before - total_payout, 'round balance after wrong');
 }

--- a/src/tests/option_round/option_buyers/refunding_bids_tests.cairo
+++ b/src/tests/option_round/option_buyers/refunding_bids_tests.cairo
@@ -1,37 +1,29 @@
 use core::traits::TryInto;
-use starknet::{ContractAddress, testing::{set_block_timestamp, set_contract_address}};
-use openzeppelin_token::erc20::interface::{ERC20ABI, ERC20ABIDispatcher, ERC20ABIDispatcherTrait,};
-use pitch_lake::{
-    option_round::contract::OptionRound::Errors,
-    tests::{
-        utils::{
-            helpers::{
-                setup::{setup_facade},
-                general_helpers::{
-                    scale_array, get_erc20_balance, get_erc20_balances, create_array_gradient,
-                    create_array_linear,
-                },
-                event_helpers::{assert_event_unused_bids_refunded, clear_event_logs},
-                accelerators::{
-                    accelerate_to_auctioning, accelerate_to_running_custom, accelerate_to_running,
-                    accelerate_to_settled, timeskip_and_end_auction,
-                    accelerate_to_auctioning_custom, timeskip_past_auction_end_date,
-                },
-            },
-            lib::{
-                test_accounts::{
-                    liquidity_provider_1, option_bidder_buyer_1, option_bidder_buyer_2,
-                    option_bidder_buyer_3, option_bidders_get, option_bidder_buyer_4,
-                },
-                variables::{decimals},
-            },
-            facades::{
-                vault_facade::{VaultFacade, VaultFacadeTrait},
-                option_round_facade::{OptionRoundFacade, OptionRoundFacadeTrait}
-            },
-        },
-    }
+use openzeppelin_token::erc20::interface::{ERC20ABI, ERC20ABIDispatcher, ERC20ABIDispatcherTrait};
+use pitch_lake::option_round::contract::OptionRound::Errors;
+use pitch_lake::tests::utils::facades::option_round_facade::{
+    OptionRoundFacade, OptionRoundFacadeTrait,
 };
+use pitch_lake::tests::utils::facades::vault_facade::{VaultFacade, VaultFacadeTrait};
+use pitch_lake::tests::utils::helpers::accelerators::{
+    accelerate_to_auctioning, accelerate_to_auctioning_custom, accelerate_to_running,
+    accelerate_to_running_custom, accelerate_to_settled, timeskip_and_end_auction,
+    timeskip_past_auction_end_date,
+};
+use pitch_lake::tests::utils::helpers::event_helpers::{
+    assert_event_unused_bids_refunded, clear_event_logs,
+};
+use pitch_lake::tests::utils::helpers::general_helpers::{
+    create_array_gradient, create_array_linear, get_erc20_balance, get_erc20_balances, scale_array,
+};
+use pitch_lake::tests::utils::helpers::setup::setup_facade;
+use pitch_lake::tests::utils::lib::test_accounts::{
+    liquidity_provider_1, option_bidder_buyer_1, option_bidder_buyer_2, option_bidder_buyer_3,
+    option_bidder_buyer_4, option_bidders_get,
+};
+use pitch_lake::tests::utils::lib::variables::decimals;
+use starknet::ContractAddress;
+use starknet::testing::{set_block_timestamp, set_contract_address};
 
 // @note Break up into separate files
 // - pending/refundable bids tests can be in the same file, needs to move to
@@ -46,7 +38,7 @@ use pitch_lake::{
 // Deploy vault and start auction
 // @return The vault facade, eth dispatcher, and span of option bidders
 fn setup_test(
-    number_of_option_buyers: u32
+    number_of_option_buyers: u32,
 ) -> (VaultFacade, ERC20ABIDispatcher, Span<ContractAddress>) {
     let (mut vault, eth) = setup_facade();
 
@@ -71,7 +63,7 @@ fn place_incremental_bids_internal(
 
     // @dev Bids start at reserve price and increment by reserve price
     let bid_prices = create_array_gradient(
-        option_reserve_price, option_reserve_price, number_of_option_bidders
+        option_reserve_price, option_reserve_price, number_of_option_bidders,
     );
 
     // @dev Bid amounts are the number of options available
@@ -127,14 +119,14 @@ fn test_refunding_bids_events() {
                         // Check refunding bids emits the correct event
                         let refund_amount = current_round.refund_bid(*bidder);
                         assert_event_unused_bids_refunded(
-                            current_round.contract_address(), *bidder, refund_amount
+                            current_round.contract_address(), *bidder, refund_amount,
                         );
                     },
-                    Option::None => { break; }
+                    Option::None => { break; },
                 }
             }
         },
-        Option::None => { panic!("this should not panic") }
+        Option::None => { panic!("this should not panic") },
     }
 }
 
@@ -160,7 +152,7 @@ fn test_refund_bids_sets_refunded_balance_to_0() {
             // Check refunded bid balance is 0 for bidder
             assert(0 == current_round.get_refundable_balance_for(*bidder), 'refunded bid shd be 0');
         },
-        Option::None => { panic!("this should not panic") }
+        Option::None => { panic!("this should not panic") },
     }
 }
 
@@ -189,14 +181,14 @@ fn test_refund_bids_eth_transfer() {
                         let eth_balance_after = eth_dispatcher.balance_of(*bidder);
                         assert(
                             eth_balance_after == eth_balance_before + refunded_amount,
-                            'lp did not receive eth'
+                            'lp did not receive eth',
                         );
                     },
-                    Option::None => { break; }
+                    Option::None => { break; },
                 }
             }
         },
-        Option::None => { panic!("this should not panic") }
+        Option::None => { panic!("this should not panic") },
     }
 }
 // @note Add test for bidder having a portion of their bid refundable

--- a/src/tests/option_round/option_buyers/tokenizing_options_tests.cairo
+++ b/src/tests/option_round/option_buyers/tokenizing_options_tests.cairo
@@ -4,25 +4,26 @@ use pitch_lake::{
         utils::{
             helpers::{
                 accelerators::{
-                    accelerate_to_running_custom, accelerate_to_auctioning,
+                    accelerate_to_auctioning, accelerate_to_running_custom,
                     timeskip_and_end_auction,
                 },
-                setup::{setup_facade, //deploy_custom_option_round
+                setup::{setup_facade //deploy_custom_option_round
                 },
                 general_helpers::{
-                    to_wei, to_wei_multi, get_erc20_balance, assert_two_arrays_equal_length
+                    assert_two_arrays_equal_length, get_erc20_balance, to_wei, to_wei_multi,
                 },
-                event_helpers::{assert_event_options_tokenized, clear_event_logs}
+                event_helpers::{assert_event_options_tokenized, clear_event_logs},
             },
-            lib::{test_accounts::{option_bidders_get, option_bidder_buyer_1},},
+            lib::{test_accounts::{option_bidder_buyer_1, option_bidders_get}},
             facades::{
+                option_round_facade::{OptionRoundFacade, OptionRoundFacadeTrait},
                 vault_facade::{VaultFacade, VaultFacadeTrait},
-                option_round_facade::{OptionRoundFacade, OptionRoundFacadeTrait}
             },
         },
-    }
+    },
 };
-use starknet::{contract_address_const, ContractAddress, testing::{set_block_timestamp}};
+use starknet::testing::set_block_timestamp;
+use starknet::{ContractAddress, contract_address_const};
 
 fn test_helper(ref vault: VaultFacade) -> (OptionRoundFacade, Span<ContractAddress>) {
     let mut current_round = vault.get_current_round();
@@ -58,7 +59,7 @@ fn test_tokenizing_options_mints_option_tokens() {
             Option::Some(bidder) => {
                 // User's option erc20 balance before tokenizing
                 let option_erc20_balance_before = get_erc20_balance(
-                    current_round.contract_address(), *bidder
+                    current_round.contract_address(), *bidder,
                 );
 
                 // Tokenize options
@@ -66,14 +67,14 @@ fn test_tokenizing_options_mints_option_tokens() {
 
                 // User's option erc20 balance after tokenizing
                 let option_erc20_balance_after = get_erc20_balance(
-                    current_round.contract_address(), *bidder
+                    current_round.contract_address(), *bidder,
                 );
 
                 // Check that the user's erc20 option balance increases by the number of options
                 // minted
                 assert(
                     option_erc20_balance_after == option_erc20_balance_before + options_minted,
-                    'wrong option erc20 balance'
+                    'wrong option erc20 balance',
                 );
             },
             Option::None => { break (); },
@@ -96,7 +97,7 @@ fn test_tokenizing_options_events() {
                 // Tokenize options
                 let options_minted = current_round.mint_options(*bidder);
                 assert_event_options_tokenized(
-                    current_round.contract_address(), *bidder, options_minted
+                    current_round.contract_address(), *bidder, options_minted,
                 );
                 // User's option erc20 balance after tokenizing
             },
@@ -137,7 +138,7 @@ fn test_tokenizing_options_twice_does_nothing() {
 
                 // User's option erc20 balance before tokenizing again
                 let option_erc20_balance_before = get_erc20_balance(
-                    current_round.contract_address(), *bidder
+                    current_round.contract_address(), *bidder,
                 );
 
                 // Tokenize again, should do nothing
@@ -145,14 +146,14 @@ fn test_tokenizing_options_twice_does_nothing() {
 
                 // User's option erc20 balance after tokenizing
                 let option_erc20_balance_after = get_erc20_balance(
-                    current_round.contract_address(), *bidder
+                    current_round.contract_address(), *bidder,
                 );
 
                 // Check that the user's erc20 option balance increases by the number of options
                 // minted
                 assert(
                     option_erc20_balance_after == option_erc20_balance_before,
-                    'wrong option erc20 balance'
+                    'wrong option erc20 balance',
                 );
             },
             Option::None => { break (); },
@@ -178,7 +179,7 @@ fn test_tokenizing_options_sets_option_storage_balance_to_0() {
                 // Check that the user's option balance in storage is set to 0 (all erc20 now)
                 assert(
                     current_round.get_mintable_options_for(*bidder) == 0,
-                    'wrong option erc20 balance'
+                    'wrong option erc20 balance',
                 );
             },
             Option::None => { break (); },

--- a/src/tests/option_round/option_buyers/update_bids_tests.cairo
+++ b/src/tests/option_round/option_buyers/update_bids_tests.cairo
@@ -1,24 +1,20 @@
 use core::traits::Into;
-use pitch_lake::{
-    option_round::contract::OptionRound::Errors,
-    tests::{
-        utils::{
-            helpers::{
-                setup::{setup_facade},
-                accelerators::{accelerate_to_auctioning, timeskip_and_end_auction},
-                event_helpers::{assert_event_auction_bid_updated, clear_event_logs},
-            },
-            lib::{
-                test_accounts::{option_bidders_get, option_bidder_buyer_1, option_bidder_buyer_2},
-                variables::{decimals},
-            },
-            facades::{
-                vault_facade::{VaultFacade, VaultFacadeTrait},
-                option_round_facade::{OptionRoundFacade, OptionRoundFacadeTrait}
-            },
-        },
-    }
+use pitch_lake::option_round::contract::OptionRound::Errors;
+use pitch_lake::tests::utils::facades::option_round_facade::{
+    OptionRoundFacade, OptionRoundFacadeTrait,
 };
+use pitch_lake::tests::utils::facades::vault_facade::{VaultFacade, VaultFacadeTrait};
+use pitch_lake::tests::utils::helpers::accelerators::{
+    accelerate_to_auctioning, timeskip_and_end_auction,
+};
+use pitch_lake::tests::utils::helpers::event_helpers::{
+    assert_event_auction_bid_updated, clear_event_logs,
+};
+use pitch_lake::tests::utils::helpers::setup::setup_facade;
+use pitch_lake::tests::utils::lib::test_accounts::{
+    option_bidder_buyer_1, option_bidder_buyer_2, option_bidders_get,
+};
+use pitch_lake::tests::utils::lib::variables::decimals;
 
 #[test]
 #[available_gas(50000000)]

--- a/src/tests/option_round/rb_tree/rb_tree_mock_contract.cairo
+++ b/src/tests/option_round/rb_tree/rb_tree_mock_contract.cairo
@@ -1,7 +1,7 @@
 use pitch_lake::types::Bid;
 
 #[starknet::interface]
-trait IRBTreeMockContract<TContractState> {
+pub trait IRBTreeMockContract<TContractState> {
     fn insert(ref self: TContractState, value: Bid);
     fn find(self: @TContractState, bid_id: felt252) -> Bid;
     fn get_tree_structure(self: @TContractState) -> Array<Array<(u256, bool, u128)>>;
@@ -11,7 +11,7 @@ trait IRBTreeMockContract<TContractState> {
 }
 
 #[starknet::contract]
-mod RBTreeMockContract {
+pub mod RBTreeMockContract {
     use pitch_lake::library::red_black_tree::RBTreeComponent;
     use pitch_lake::types::Bid;
 
@@ -31,7 +31,7 @@ mod RBTreeMockContract {
     #[event]
     #[derive(Drop, starknet::Event)]
     enum Event {
-        RBTreeEvent: RBTreeComponent::Event
+        RBTreeEvent: RBTreeComponent::Event,
     }
 
     #[abi(embed_v0)]

--- a/src/tests/option_round/rb_tree/rb_tree_stress_tests.cairo
+++ b/src/tests/option_round/rb_tree/rb_tree_stress_tests.cairo
@@ -1,16 +1,9 @@
 use core::pedersen::pedersen;
-use pitch_lake::{
-    types::Bid,
-    tests::{
-        utils::helpers::setup::setup_rb_tree_test,
-        option_round::rb_tree::{
-            rb_tree_tests::{insert, mock_address, MOCK_ADDRESS, delete, create_bid},
-            rb_tree_mock_contract::{
-                IRBTreeMockContractDispatcher, IRBTreeMockContractDispatcherTrait
-            }
-        }
-    },
+use pitch_lake::tests::option_round::rb_tree::rb_tree_mock_contract::IRBTreeMockContractDispatcherTrait;
+use pitch_lake::tests::option_round::rb_tree::rb_tree_tests::{
+    MOCK_ADDRESS, create_bid, delete, insert, mock_address,
 };
+use pitch_lake::tests::utils::helpers::setup::setup_rb_tree_test;
 
 #[test]
 #[available_gas(50000000000)]
@@ -24,19 +17,19 @@ fn test_add_1_to_100_delete_100_to_1() {
         let is_tree_valid = rb_tree.is_tree_valid();
         assert(is_tree_valid, 'Tree is not valid');
         i += 1;
-    };
+    }
 
     i = 100;
     while i >= 1 {
-        let id = poseidon::poseidon_hash_span(
-            array![mock_address(MOCK_ADDRESS).into(), i.try_into().unwrap()].span()
+        let id = core::poseidon::poseidon_hash_span(
+            array![mock_address(MOCK_ADDRESS).into(), i.try_into().unwrap()].span(),
         );
         delete(rb_tree, id);
         println!("Deleted: {:?}", i);
         let is_tree_valid = rb_tree.is_tree_valid();
         assert(is_tree_valid, 'Tree is not valid');
         i -= 1;
-    };
+    }
 
     let is_tree_valid = rb_tree.is_tree_valid();
     assert(is_tree_valid, 'Tree is not valid');
@@ -54,12 +47,12 @@ fn test_add_1_to_100_delete_1_to_100() {
         let is_tree_valid = rb_tree.is_tree_valid();
         assert(is_tree_valid, 'Tree is not valid');
         i += 1;
-    };
+    }
 
     i = 1;
     while i <= 100 {
-        let id = poseidon::poseidon_hash_span(
-            array![mock_address(MOCK_ADDRESS).into(), i.try_into().unwrap()].span()
+        let id = core::poseidon::poseidon_hash_span(
+            array![mock_address(MOCK_ADDRESS).into(), i.try_into().unwrap()].span(),
         );
         delete(rb_tree, id);
         println!("Deleted: {:?}", i);
@@ -112,7 +105,7 @@ fn testing_random_insertion_and_deletion() {
         assert(is_tree_valid, 'Tree is not valid');
 
         i += 1;
-    };
+    }
 
     let mut j: u32 = 0;
 

--- a/src/tests/option_round/rb_tree/rb_tree_tests.cairo
+++ b/src/tests/option_round/rb_tree/rb_tree_tests.cairo
@@ -1,23 +1,16 @@
-use core::pedersen::pedersen;
-use starknet::{contract_address_const, ContractAddress};
-use pitch_lake::{
-    types::{Bid},
-    tests::{
-        option_round::{
-            rb_tree::rb_tree_mock_contract::{
-                IRBTreeMockContractDispatcher, IRBTreeMockContractDispatcherTrait
-            }
-        },
-        utils::helpers::setup::setup_rb_tree_test
-    },
+use pitch_lake::tests::option_round::rb_tree::rb_tree_mock_contract::{
+    IRBTreeMockContractDispatcher, IRBTreeMockContractDispatcherTrait,
 };
+use pitch_lake::tests::utils::helpers::setup::setup_rb_tree_test;
+use pitch_lake::types::Bid;
+use starknet::ContractAddress;
 
-const BLACK: bool = false;
-const RED: bool = true;
-const MOCK_ADDRESS: felt252 = 123456;
+pub const BLACK: bool = false;
+pub const RED: bool = true;
+pub const MOCK_ADDRESS: felt252 = 123456;
 
-fn mock_address(value: felt252) -> ContractAddress {
-    contract_address_const::<'test_contract_address'>()
+pub fn mock_address(value: felt252) -> ContractAddress {
+    'test_contract_address'.try_into().unwrap()
 }
 
 // Tests for insertion
@@ -70,10 +63,9 @@ fn test_insert_into_empty_tree() {
 
     let tree = rb_tree.get_tree_structure();
     let expected_tree_structure = array![
-        array![(5, false, 0)],
-        array![(2, true, 0), (7, true, 1)],
+        array![(5, false, 0)], array![(2, true, 0), (7, true, 1)],
         array![(1, false, 0), (4, false, 1), (6, false, 2), (9, false, 3)],
-        array![(3, true, 2), (15, true, 7)]
+        array![(3, true, 2), (15, true, 7)],
     ];
     compare_tree_structures(@tree, @expected_tree_structure);
 
@@ -128,11 +120,9 @@ fn test_recoloring_only() {
     insert(rb_tree, 25, 10);
 
     let tree_after_recolor = array![
-        array![(31, false, 0)],
-        array![(11, false, 0), (41, false, 1)],
+        array![(31, false, 0)], array![(11, false, 0), (41, false, 1)],
         array![(1, false, 0), (27, true, 1), (36, false, 2), (46, false, 3)],
-        array![(23, false, 2), (29, false, 3)],
-        array![(25, true, 5)]
+        array![(23, false, 2), (29, false, 3)], array![(25, true, 5)],
     ];
     let tree_structure = rb_tree.get_tree_structure();
     compare_tree_structures(@tree_structure, @tree_after_recolor);
@@ -180,11 +170,9 @@ fn test_recoloring_two() {
     insert(rb_tree, 40, 10);
 
     let tree_after_recolor = array![
-        array![(31, false, 0)],
-        array![(11, false, 0), (41, false, 1)],
+        array![(31, false, 0)], array![(11, false, 0), (41, false, 1)],
         array![(1, false, 0), (27, false, 1), (36, true, 2), (46, false, 3)],
-        array![(33, false, 4), (38, false, 5)],
-        array![(40, true, 11)]
+        array![(33, false, 4), (38, false, 5)], array![(40, true, 11)],
     ];
     let tree_structure = rb_tree.get_tree_structure();
     compare_tree_structures(@tree_structure, @tree_after_recolor);
@@ -220,9 +208,8 @@ fn test_right_rotation() {
     insert(rb_tree, 24, 6);
 
     let tree_after_right_rotation = array![
-        array![(21, false, 0)],
-        array![(1, false, 0), (26, false, 1)],
-        array![(18, true, 1), (24, true, 2), (31, true, 3)]
+        array![(21, false, 0)], array![(1, false, 0), (26, false, 1)],
+        array![(18, true, 1), (24, true, 2), (31, true, 3)],
     ];
     let tree_structure = rb_tree.get_tree_structure();
     compare_tree_structures(@tree_structure, @tree_after_right_rotation);
@@ -256,9 +243,8 @@ fn test_left_rotation_no_sibling() {
     insert(rb_tree, 9, 5);
 
     let tree_after_left_rotation = array![
-        array![(10, false, 0)],
-        array![(8, false, 0), (20, false, 1)],
-        array![(7, true, 0), (9, true, 1)]
+        array![(10, false, 0)], array![(8, false, 0), (20, false, 1)],
+        array![(7, true, 0), (9, true, 1)],
     ];
 
     let tree_structure = rb_tree.get_tree_structure();
@@ -296,9 +282,8 @@ fn test_right_rotation_no_sibling_left_subtree() {
 
     let tree = rb_tree.get_tree_structure();
     let expected_tree_structure = array![
-        array![(23, false, 0)],
-        array![(2, false, 0), (33, false, 1)],
-        array![(1, true, 0), (3, true, 1), (28, true, 2)]
+        array![(23, false, 0)], array![(2, false, 0), (33, false, 1)],
+        array![(1, true, 0), (3, true, 1), (28, true, 2)],
     ];
     compare_tree_structures(@tree, @expected_tree_structure);
 
@@ -333,9 +318,8 @@ fn test_left_right_rotation_no_sibling() {
     insert(rb_tree, 28, 6);
 
     let tree_after_left_right_rotation = array![
-        array![(21, false, 0)],
-        array![(1, false, 0), (28, false, 1)],
-        array![(18, true, 1), (26, true, 2), (31, true, 3)]
+        array![(21, false, 0)], array![(1, false, 0), (28, false, 1)],
+        array![(18, true, 1), (26, true, 2), (31, true, 3)],
     ];
 
     let tree_structure = rb_tree.get_tree_structure();
@@ -372,9 +356,8 @@ fn test_right_left_rotation_no_sibling() {
 
     let result = rb_tree.get_tree_structure();
     let expected_tree_structure = array![
-        array![(21, false, 0)],
-        array![(13, false, 0), (31, false, 1)],
-        array![(1, true, 0), (18, true, 1), (26, true, 2)]
+        array![(21, false, 0)], array![(13, false, 0), (31, false, 1)],
+        array![(1, true, 0), (18, true, 1), (26, true, 2)],
     ];
 
     compare_tree_structures(@result, @expected_tree_structure);
@@ -422,10 +405,9 @@ fn test_recolor_lr() {
     insert(rb_tree, 25, 10);
 
     let tree_after_recolor = array![
-        array![(27, false, 0)],
-        array![(11, true, 0), (31, true, 1)],
+        array![(27, false, 0)], array![(11, true, 0), (31, true, 1)],
         array![(1, false, 0), (22, false, 1), (30, false, 2), (41, false, 3)],
-        array![(25, true, 3), (36, true, 6), (51, true, 7)]
+        array![(25, true, 3), (36, true, 6), (51, true, 7)],
     ];
     let tree_structure = rb_tree.get_tree_structure();
     compare_tree_structures(@tree_structure, @tree_after_recolor);
@@ -450,7 +432,7 @@ fn test_functional_test_build_tree() {
 
     insert(rb_tree, 4, 3);
     let tree_with_right_node = array![
-        array![(2, false, 0)], array![(1, true, 0)], array![(4, true, 0)]
+        array![(2, false, 0)], array![(1, true, 0)], array![(4, true, 0)],
     ];
     let tree_structure = rb_tree.get_tree_structure();
     compare_tree_structures(@tree_structure, @tree_with_right_node);
@@ -459,7 +441,7 @@ fn test_functional_test_build_tree() {
 
     insert(rb_tree, 5, 4);
     let tree_after_recolor_parents = array![
-        array![(2, false, 0)], array![(1, false, 0), (4, false, 1)], array![(5, true, 3)]
+        array![(2, false, 0)], array![(1, false, 0), (4, false, 1)], array![(5, true, 3)],
     ];
     let tree_structure = rb_tree.get_tree_structure();
     compare_tree_structures(@tree_structure, @tree_after_recolor_parents);
@@ -468,9 +450,8 @@ fn test_functional_test_build_tree() {
 
     insert(rb_tree, 9, 5);
     let tree_after_left_rotation = array![
-        array![(2, false, 0)],
-        array![(1, false, 0), (5, false, 1)],
-        array![(4, true, 2), (9, true, 3)]
+        array![(2, false, 0)], array![(1, false, 0), (5, false, 1)],
+        array![(4, true, 2), (9, true, 3)],
     ];
     let tree_structure = rb_tree.get_tree_structure();
     compare_tree_structures(@tree_structure, @tree_after_left_rotation);
@@ -479,10 +460,8 @@ fn test_functional_test_build_tree() {
 
     insert(rb_tree, 3, 6);
     let tree_after_recolor = array![
-        array![(2, false, 0)],
-        array![(1, false, 0), (5, true, 1)],
-        array![(4, false, 2), (9, false, 3)],
-        array![(3, true, 4)],
+        array![(2, false, 0)], array![(1, false, 0), (5, true, 1)],
+        array![(4, false, 2), (9, false, 3)], array![(3, true, 4)],
     ];
     let tree_structure = rb_tree.get_tree_structure();
     compare_tree_structures(@tree_structure, @tree_after_recolor);
@@ -491,10 +470,8 @@ fn test_functional_test_build_tree() {
 
     insert(rb_tree, 6, 7);
     let tree_after_insertion = array![
-        array![(2, false, 0)],
-        array![(1, false, 0), (5, true, 1)],
-        array![(4, false, 2), (9, false, 3)],
-        array![(3, true, 4), (6, true, 6)],
+        array![(2, false, 0)], array![(1, false, 0), (5, true, 1)],
+        array![(4, false, 2), (9, false, 3)], array![(3, true, 4), (6, true, 6)],
     ];
     let tree_structure = rb_tree.get_tree_structure();
     compare_tree_structures(@tree_structure, @tree_after_insertion);
@@ -504,10 +481,8 @@ fn test_functional_test_build_tree() {
     insert(rb_tree, 7, 8);
     let tree_structure = rb_tree.get_tree_structure();
     let tree_after_left_right_rotation_recolor = array![
-        array![(2, false, 0)],
-        array![(1, false, 0), (5, true, 1)],
-        array![(4, false, 2), (7, false, 3)],
-        array![(3, true, 4), (6, true, 6), (9, true, 7)],
+        array![(2, false, 0)], array![(1, false, 0), (5, true, 1)],
+        array![(4, false, 2), (7, false, 3)], array![(3, true, 4), (6, true, 6), (9, true, 7)],
     ];
     compare_tree_structures(@tree_structure, @tree_after_left_right_rotation_recolor);
     let is_tree_valid = rb_tree.is_tree_valid();
@@ -516,8 +491,7 @@ fn test_functional_test_build_tree() {
     insert(rb_tree, 15, 9);
     let tree_structure = rb_tree.get_tree_structure();
     let tree_after_recolor = array![
-        array![(5, false, 0)],
-        array![(2, true, 0), (7, true, 1)],
+        array![(5, false, 0)], array![(2, true, 0), (7, true, 1)],
         array![(1, false, 0), (4, false, 1), (6, false, 2), (9, false, 3)],
         array![(3, true, 2), (15, true, 7)],
     ];
@@ -559,10 +533,9 @@ fn test_right_left_rotation_after_recolor() {
     insert(rb_tree, 19, 8);
 
     let tree_after_right_left_rotation = array![
-        array![(15, false, 0)],
-        array![(10, true, 0), (20, true, 1)],
+        array![(15, false, 0)], array![(10, true, 0), (20, true, 1)],
         array![(5, false, 0), (12, false, 1), (17, false, 2), (25, false, 3)],
-        array![(19, true, 5)]
+        array![(19, true, 5)],
     ];
 
     let tree_structure = rb_tree.get_tree_structure();
@@ -611,10 +584,9 @@ fn test_right_rotation_after_recolor() {
     insert(rb_tree, 1, 10);
 
     let tree_after_right_rotation = array![
-        array![(13, false, 0)],
-        array![(3, true, 0), (33, true, 1)],
+        array![(13, false, 0)], array![(3, true, 0), (33, true, 1)],
         array![(2, false, 0), (4, false, 1), (29, false, 2), (43, false, 3)],
-        array![(1, true, 0), (38, true, 6), (48, true, 7)]
+        array![(1, true, 0), (38, true, 6), (48, true, 7)],
     ];
 
     let tree_structure = rb_tree.get_tree_structure();
@@ -739,10 +711,9 @@ fn test_delete_single_deep_child() {
     delete(rb_tree, node_49);
 
     let tree_after_deletion = array![
-        array![(20, false, 0)],
-        array![(10, false, 0), (38, true, 1)],
+        array![(20, false, 0)], array![(10, false, 0), (38, true, 1)],
         array![(5, true, 0), (15, true, 1), (28, false, 2), (48, false, 3)],
-        array![(23, true, 4), (29, true, 5), (41, true, 6)]
+        array![(23, true, 4), (29, true, 5), (41, true, 6)],
     ];
     let tree_structure = rb_tree.get_tree_structure();
     compare_tree_structures(@tree_structure, @tree_after_deletion);
@@ -787,9 +758,8 @@ fn test_deletion_red_node_red_successor_no_children() {
     delete(rb_tree, node_41);
 
     let tree_after_deletion = array![
-        array![(16, false, 0)],
-        array![(11, true, 0), (42, true, 1)],
-        array![(1, false, 0), (13, false, 1), (26, false, 2), (44, false, 3)]
+        array![(16, false, 0)], array![(11, true, 0), (42, true, 1)],
+        array![(1, false, 0), (13, false, 1), (26, false, 2), (44, false, 3)],
     ];
     let tree_structure = rb_tree.get_tree_structure();
     compare_tree_structures(@tree_structure, @tree_after_deletion);
@@ -837,10 +807,9 @@ fn test_mirror_deletion_red_node_red_successor_no_children() {
     delete(rb_tree, node_11);
 
     let tree_after_deletion = array![
-        array![(16, false, 0)],
-        array![(12, true, 0), (41, true, 1)],
+        array![(16, false, 0)], array![(12, true, 0), (41, true, 1)],
         array![(1, false, 0), (13, false, 1), (26, false, 2), (44, false, 3)],
-        array![(42, true, 6)]
+        array![(42, true, 6)],
     ];
     let tree_structure = rb_tree.get_tree_structure();
     compare_tree_structures(@tree_structure, @tree_after_deletion);
@@ -891,10 +860,9 @@ fn test_deletion_black_node_black_successor_right_red_child() {
     delete(rb_tree, node_36);
 
     let tree_after_deletion = array![
-        array![(16, false, 0)],
-        array![(11, false, 0), (38, false, 1)],
+        array![(16, false, 0)], array![(11, false, 0), (38, false, 1)],
         array![(1, false, 0), (13, false, 1), (26, false, 2), (44, true, 3)],
-        array![(41, false, 6), (47, false, 7)]
+        array![(41, false, 6), (47, false, 7)],
     ];
 
     let tree_structure = rb_tree.get_tree_structure();
@@ -932,7 +900,7 @@ fn test_deletion_black_node_black_successor_no_child() {
 
     let tree = rb_tree.get_tree_structure();
     let expected_tree_structure = array![
-        array![(31, false, 0)], array![(1, false, 0), (41, false, 1)], array![(49, true, 3)]
+        array![(31, false, 0)], array![(1, false, 0), (41, false, 1)], array![(49, true, 3)],
     ];
     compare_tree_structures(@tree, @expected_tree_structure);
 
@@ -968,7 +936,7 @@ fn test_deletion_black_node_no_successor() {
 
     let tree = rb_tree.get_tree_structure();
     let expected_tree_structure = array![
-        array![(41, false, 0)], array![(21, false, 0), (51, false, 1)], array![(36, true, 1)]
+        array![(41, false, 0)], array![(21, false, 0), (51, false, 1)], array![(36, true, 1)],
     ];
     compare_tree_structures(@tree, @expected_tree_structure);
 
@@ -1004,7 +972,7 @@ fn test_mirror_deletion_black_node_no_successor() {
 
     let tree = rb_tree.get_tree_structure();
     let expected_tree_structure = array![
-        array![(5, false, 0)], array![(1, false, 0), (10, false, 1)], array![(7, true, 2)]
+        array![(5, false, 0)], array![(1, false, 0), (10, false, 1)], array![(7, true, 2)],
     ];
 
     compare_tree_structures(@tree, @expected_tree_structure);
@@ -1072,10 +1040,8 @@ fn test_deletion_black_node_no_successor_3() {
     delete(rb_tree, node_4);
 
     let tree_after_deletion = array![
-        array![(30, false, 0)],
-        array![(10, false, 0), (50, false, 1)],
-        array![(7, false, 0), (15, false, 1), (40, false, 2), (70, false, 3)],
-        array![(9, true, 1)]
+        array![(30, false, 0)], array![(10, false, 0), (50, false, 1)],
+        array![(7, false, 0), (15, false, 1), (40, false, 2), (70, false, 3)], array![(9, true, 1)],
     ];
 
     let tree_structure = rb_tree.get_tree_structure();
@@ -1125,10 +1091,8 @@ fn test_deletion_black_node_successor() {
     delete(rb_tree, node_10);
 
     let tree_after_deletion = array![
-        array![(20, false, 0)],
-        array![(5, false, 0), (60, false, 1)],
-        array![(3, false, 0), (7, false, 1), (40, false, 2), (80, false, 3)],
-        array![(50, true, 5)]
+        array![(20, false, 0)], array![(5, false, 0), (60, false, 1)],
+        array![(3, false, 0), (7, false, 1), (40, false, 2), (80, false, 3)], array![(50, true, 5)],
     ];
 
     let tree_structure = rb_tree.get_tree_structure();
@@ -1177,10 +1141,8 @@ fn test_mirror_deletion_black_node_successor() {
     delete(rb_tree, node_15);
 
     let tree_after_deletion = array![
-        array![(20, false, 0)],
-        array![(8, false, 0), (30, false, 1)],
-        array![(6, false, 0), (10, false, 1), (25, false, 2), (35, false, 3)],
-        array![(9, true, 2)]
+        array![(20, false, 0)], array![(8, false, 0), (30, false, 1)],
+        array![(6, false, 0), (10, false, 1), (25, false, 2), (35, false, 3)], array![(9, true, 2)],
     ];
 
     let tree_structure = rb_tree.get_tree_structure();
@@ -1216,9 +1178,8 @@ fn test_delete_tree_one_by_one() {
 
     let final_tree = rb_tree.get_tree_structure();
     let expected_tree_structure = array![
-        array![(57, false, 0)],
-        array![(24, false, 0), (60, false, 1)],
-        array![(14, true, 0), (49, true, 1), (93, true, 3)]
+        array![(57, false, 0)], array![(24, false, 0), (60, false, 1)],
+        array![(14, true, 0), (49, true, 1), (93, true, 3)],
     ];
     compare_tree_structures(@final_tree, @expected_tree_structure);
     let is_tree_valid = rb_tree.is_tree_valid();
@@ -1227,35 +1188,35 @@ fn test_delete_tree_one_by_one() {
 
 // Test Utilities
 
-fn create_bid(price: u256, tree_nonce: u64) -> Bid {
+pub fn create_bid(price: u256, tree_nonce: u64) -> Bid {
     let owner = mock_address(MOCK_ADDRESS);
-    let bid_id = poseidon::poseidon_hash_span(
-        array![owner.into(), tree_nonce.try_into().unwrap()].span()
+    let bid_id = core::poseidon::poseidon_hash_span(
+        array![owner.into(), tree_nonce.try_into().unwrap()].span(),
     );
     Bid { bid_id, owner, amount: 0, price, tree_nonce }
 }
 
-fn insert(rb_tree: IRBTreeMockContractDispatcher, price: u256, tree_nonce: u64) -> felt252 {
+pub fn insert(rb_tree: IRBTreeMockContractDispatcher, price: u256, tree_nonce: u64) -> felt252 {
     let owner = mock_address(MOCK_ADDRESS);
-    let bid_id = poseidon::poseidon_hash_span(
-        array![owner.into(), tree_nonce.try_into().unwrap()].span()
+    let bid_id = core::poseidon::poseidon_hash_span(
+        array![owner.into(), tree_nonce.try_into().unwrap()].span(),
     );
     rb_tree.insert(Bid { bid_id, owner, amount: 0, price, tree_nonce });
     return bid_id;
 }
 
-fn is_tree_valid(rb_tree: IRBTreeMockContractDispatcher) -> bool {
+pub fn is_tree_valid(rb_tree: IRBTreeMockContractDispatcher) -> bool {
     let is_tree_valid = rb_tree.is_tree_valid();
     //println!("Is tree valid: {:?}", is_tree_valid);
     is_tree_valid
 }
 
-fn delete(rb_tree: IRBTreeMockContractDispatcher, bid_id: felt252) {
+pub fn delete(rb_tree: IRBTreeMockContractDispatcher, bid_id: felt252) {
     rb_tree.delete(bid_id);
 }
 
-fn compare_tree_structures(
-    actual: @Array<Array<(u256, bool, u128)>>, expected: @Array<Array<(u256, bool, u128)>>
+pub fn compare_tree_structures(
+    actual: @Array<Array<(u256, bool, u128)>>, expected: @Array<Array<(u256, bool, u128)>>,
 ) {
     if actual.len() != expected.len() {
         return;
@@ -1272,7 +1233,7 @@ fn compare_tree_structures(
     }
 }
 
-fn compare_inner(actual: @Array<(u256, bool, u128)>, expected: @Array<(u256, bool, u128)>) {
+pub fn compare_inner(actual: @Array<(u256, bool, u128)>, expected: @Array<(u256, bool, u128)>) {
     if actual.len() != expected.len() {
         return;
     }
@@ -1287,7 +1248,7 @@ fn compare_inner(actual: @Array<(u256, bool, u128)>, expected: @Array<(u256, boo
     }
 }
 
-fn compare_tuple(actual: (u256, bool, u128), expected: (u256, bool, u128)) {
+pub fn compare_tuple(actual: (u256, bool, u128), expected: (u256, bool, u128)) {
     let (actual_price, actual_color, actual_position) = actual;
     let (expected_price, expected_color, expected_position) = expected;
 

--- a/src/tests/option_round/state_transition/auction_end/clearing_price_tests.cairo
+++ b/src/tests/option_round/state_transition/auction_end/clearing_price_tests.cairo
@@ -1,30 +1,20 @@
-use pitch_lake::{
-    tests::{
-        utils::{
-            helpers::{
-                accelerators::{
-                    accelerate_to_auctioning, accelerate_to_running, accelerate_to_running_custom,
-                    timeskip_and_end_auction,
-                },
-                setup::{setup_facade, setup_test_auctioning_bidders},
-                general_helpers::{
-                    create_array_linear, create_array_gradient, create_array_gradient_reverse
-                },
-            },
-            lib::{
-                test_accounts::{
-                    option_bidder_buyer_1, option_bidder_buyer_2, option_bidder_buyer_3,
-                    option_bidder_buyer_4, option_bidders_get,
-                },
-                variables::{decimals},
-            },
-            facades::{
-                vault_facade::{VaultFacade, VaultFacadeTrait},
-                option_round_facade::{OptionRoundFacade, OptionRoundFacadeTrait},
-            },
-        },
-    }
+use pitch_lake::tests::utils::facades::option_round_facade::{
+    OptionRoundFacade, OptionRoundFacadeTrait,
 };
+use pitch_lake::tests::utils::facades::vault_facade::{VaultFacade, VaultFacadeTrait};
+use pitch_lake::tests::utils::helpers::accelerators::{
+    accelerate_to_auctioning, accelerate_to_running, accelerate_to_running_custom,
+    timeskip_and_end_auction,
+};
+use pitch_lake::tests::utils::helpers::general_helpers::{
+    create_array_gradient, create_array_gradient_reverse, create_array_linear,
+};
+use pitch_lake::tests::utils::helpers::setup::{setup_facade, setup_test_auctioning_bidders};
+use pitch_lake::tests::utils::lib::test_accounts::{
+    option_bidder_buyer_1, option_bidder_buyer_2, option_bidder_buyer_3, option_bidder_buyer_4,
+    option_bidders_get,
+};
+use pitch_lake::tests::utils::lib::variables::decimals;
 use starknet::testing::{set_block_timestamp, set_contract_address};
 
 // Test clearing price is 0 before auction end
@@ -73,7 +63,7 @@ fn test_clearing_price_is_only_bid_price() {
     let bid_amount = array![total_options_available].span();
     let bid_price = array![current_round.get_reserve_price() + 1].span();
     let (clearing_price, _) = accelerate_to_running_custom(
-        ref vault, bidder, bid_amount, bid_price
+        ref vault, bidder, bid_amount, bid_price,
     );
 
     assert(clearing_price == *bid_price[0], 'clearing price wrong');
@@ -96,7 +86,7 @@ fn test_clearing_price_is_highest_price_to_sell_all_options() {
         .span();
 
     let (clearing_price, _) = accelerate_to_running_custom(
-        ref vault, bidders, bid_amounts, bid_prices
+        ref vault, bidders, bid_amounts, bid_prices,
     );
     // Check that clearing price is the 2nd bid price (max price to sell all options)
     assert(clearing_price == *bid_prices[1], 'clearing price wrong');

--- a/src/tests/option_round/state_transition/auction_end/premium_earned_tests.cairo
+++ b/src/tests/option_round/state_transition/auction_end/premium_earned_tests.cairo
@@ -1,30 +1,16 @@
-use starknet::testing::{set_block_timestamp, set_contract_address, ContractAddress};
-use openzeppelin_token::erc20::interface::{ERC20ABIDispatcherTrait,};
-use pitch_lake::tests::{
-    utils::{
-        helpers::{
-            event_helpers::{assert_event_transfer, assert_event_vault_withdrawal},
-            accelerators::{
-                accelerate_to_auctioning, accelerate_to_auctioning_custom, accelerate_to_running,
-                accelerate_to_running_custom, accelerate_to_settled, clear_event_logs
-            },
-            setup::{setup_facade},
-        },
-        lib::{
-            test_accounts::{
-                liquidity_provider_1, liquidity_provider_2, liquidity_provider_3,
-                liquidity_provider_4, liquidity_provider_5, option_bidder_buyer_1,
-                option_bidder_buyer_2, option_bidder_buyer_3, liquidity_providers_get
-            },
-            variables::{decimals},
-        },
-        facades::{
-            option_round_facade::{OptionRoundFacade, OptionRoundFacadeTrait},
-            vault_facade::{VaultFacade, VaultFacadeTrait},
-        },
-    },
+use pitch_lake::tests::utils::facades::option_round_facade::{
+    OptionRoundFacade, OptionRoundFacadeTrait,
 };
-use debug::PrintTrait;
+use pitch_lake::tests::utils::facades::vault_facade::{VaultFacade, VaultFacadeTrait};
+use pitch_lake::tests::utils::helpers::accelerators::{
+    accelerate_to_auctioning, accelerate_to_auctioning_custom, accelerate_to_running,
+};
+use pitch_lake::tests::utils::helpers::setup::setup_facade;
+use pitch_lake::tests::utils::lib::test_accounts::{
+    liquidity_provider_1, liquidity_providers_get, option_bidder_buyer_1,
+};
+use pitch_lake::tests::utils::lib::variables::decimals;
+use starknet::ContractAddress;
 
 // @note move these tests to ./src/tests/option_round/state_transition/auction_end_tests
 
@@ -72,7 +58,7 @@ fn test_premium_amount_for_liquidity_providers_2() {
     // LPs
     let liquidity_providers = liquidity_providers_get(4);
     // Deposit amounts
-    let amounts = array![250 * decimals(), 500 * decimals(), 1000 * decimals(), 1500 * decimals(),];
+    let amounts = array![250 * decimals(), 500 * decimals(), 1000 * decimals(), 1500 * decimals()];
 
     _test_premiums_collectable_helper(ref vault_facade, liquidity_providers.span(), amounts.span());
 }
@@ -85,7 +71,7 @@ fn test_premium_amount_for_liquidity_providers_3() {
     // LPs
     let liquidity_providers = liquidity_providers_get(4);
     // Deposit amounts
-    let amounts = array![333 * decimals(), 333 * decimals(), 333 * decimals(), 1 * decimals(),];
+    let amounts = array![333 * decimals(), 333 * decimals(), 333 * decimals(), 1 * decimals()];
 
     _test_premiums_collectable_helper(ref vault_facade, liquidity_providers.span(), amounts.span());
 }
@@ -99,7 +85,7 @@ fn test_premium_amount_for_liquidity_providers_4() {
     let liquidity_providers = liquidity_providers_get(5);
     // Deposit amounts
     let amounts = array![
-        25 * decimals(), 25 * decimals(), 25 * decimals(), 25 * decimals(), 1 * decimals()
+        25 * decimals(), 25 * decimals(), 25 * decimals(), 25 * decimals(), 1 * decimals(),
     ];
 
     _test_premiums_collectable_helper(ref vault_facade, liquidity_providers.span(), amounts.span());
@@ -268,7 +254,7 @@ fn test_premium_amount_for_liquidity_providers_5() {
 
 // Internal tester to check the premiums collectable for LPs is correct
 fn _test_premiums_collectable_helper(
-    ref vault: VaultFacade, liquidity_providers: Span<ContractAddress>, amounts: Span<u256>
+    ref vault: VaultFacade, liquidity_providers: Span<ContractAddress>, amounts: Span<u256>,
 ) {
     assert(liquidity_providers.len() == amounts.len(), 'Span missmatch');
 
@@ -285,14 +271,12 @@ fn _test_premiums_collectable_helper(
     let total_premium = current_round.total_premiums();
 
     // Check each LP's collectable premiums matches expected
-    for i in 0
-        ..liquidity_providers
-            .len() {
-                let deposit_amount = *amounts.at(i);
+    for i in 0..liquidity_providers.len() {
+        let deposit_amount = *amounts.at(i);
 
-                let exp_lp_unlocked = (deposit_amount * (unsold_liq + total_premium)) / (total_liq);
-                let lp_unlocked = vault.get_lp_unlocked_balance(*liquidity_providers.at(i));
+        let exp_lp_unlocked = (deposit_amount * (unsold_liq + total_premium)) / (total_liq);
+        let lp_unlocked = vault.get_lp_unlocked_balance(*liquidity_providers.at(i));
 
-                assert(lp_unlocked == exp_lp_unlocked, 'LP unlocked wrong');
-            };
+        assert(lp_unlocked == exp_lp_unlocked, 'LP unlocked wrong');
+    };
 }

--- a/src/tests/option_round/state_transition/caller_is_not_vault_tests.cairo
+++ b/src/tests/option_round/state_transition/caller_is_not_vault_tests.cairo
@@ -1,42 +1,22 @@
-use starknet::{
-    get_block_timestamp, ContractAddress, contract_address_const,
-    testing::{set_contract_address, set_block_timestamp}
+use pitch_lake::option_round::contract::OptionRound::Errors;
+use pitch_lake::option_round::interface::PricingData;
+use pitch_lake::tests::utils::facades::option_round_facade::OptionRoundFacadeTrait;
+use pitch_lake::tests::utils::facades::vault_facade::VaultFacadeTrait;
+use pitch_lake::tests::utils::helpers::accelerators::{
+    accelerate_to_auctioning, accelerate_to_running,
 };
-use pitch_lake::{
-    vault::contract::Vault, vault::contract::Vault::Errors as vErrors,
-    option_round::contract::OptionRound::Errors, vault::interface::{JobRequest},
-    option_round::interface::PricingData, library::pricing_utils,
-    tests::{
-        utils::{
-            helpers::{
-                accelerators::{
-                    accelerate_to_auctioning, accelerate_to_running, accelerate_to_running_custom,
-                    accelerate_to_settled, clear_event_logs
-                },
-                setup::{setup_facade, deploy_vault, deploy_eth},
-                event_helpers::{assert_fossil_callback_success_event}, general_helpers::{to_gwei},
-                event_helpers::{assert_event_pricing_data_set},
-            },
-            lib::{
-                test_accounts::{
-                    liquidity_provider_1, option_bidder_buyer_1, option_bidder_buyer_2,
-                    option_bidder_buyer_3, option_bidder_buyer_4, option_bidders_get,
-                },
-                variables::{decimals},
-            },
-            facades::{
-                vault_facade::{VaultFacade, VaultFacadeTrait},
-                option_round_facade::{OptionRoundFacade, OptionRoundFacadeTrait},
-            },
-        },
-    }
-};
+use pitch_lake::tests::utils::helpers::general_helpers::to_gwei;
+use pitch_lake::tests::utils::helpers::setup::setup_facade;
+use pitch_lake::tests::utils::lib::test_accounts::{liquidity_provider_1, option_bidder_buyer_1};
+use pitch_lake::tests::utils::lib::variables::decimals;
+use starknet::ContractAddress;
+use starknet::testing::{set_block_timestamp, set_contract_address};
 
 const salt: u64 = 0x123;
 const err: felt252 = Errors::CallerIsNotVault;
 
 fn not_vault() -> ContractAddress {
-    contract_address_const::<'not vault'>()
+    'not vault'.try_into().unwrap()
 }
 
 // Test that only the vault can start an auction
@@ -81,7 +61,7 @@ fn test_only_vault_can_settle_option_round() {
 }
 
 fn get_random_pricing_data_points() -> PricingData {
-    PricingData { strike_price: to_gwei(5829), cap_level: 20084, reserve_price: to_gwei(482745), }
+    PricingData { strike_price: to_gwei(5829), cap_level: 20084, reserve_price: to_gwei(482745) }
 }
 
 #[test]
@@ -107,7 +87,7 @@ fn test_set_pricing_data_on_round() {
 
     let random_pricing_data = get_random_pricing_data_points();
     set_contract_address(vault.contract_address());
-    round.set_pricing_data(random_pricing_data.clone());
+    round.set_pricing_data(random_pricing_data);
 
     let reserve_price = round.get_reserve_price();
     let cap_level = round.get_cap_level();

--- a/src/tests/option_round/state_transition/fulfill_request_tests.cairo
+++ b/src/tests/option_round/state_transition/fulfill_request_tests.cairo
@@ -23,10 +23,7 @@ use pitch_lake::{
                 general_helpers::{to_gwei},
             },
             facades::{
-                vault_facade::{
-                    VaultFacadeImpl, VaultFacade, VaultFacadeTrait,
-                    l1_data_to_verifier_data_serialized, l1_data_to_verifier_data
-                },
+                vault_facade::{VaultFacadeImpl, VaultFacade, VaultFacadeTrait},
                 option_round_facade::{OptionRoundFacade, OptionRoundFacadeTrait},
             },
         },
@@ -39,16 +36,6 @@ use core::integer::{I128Neg};
 
 fn get_mock_l1_data() -> L1Data {
     L1Data { twap: to_gwei(33) / 100, max_return: 1009, reserve_price: to_gwei(11) / 10 }
-}
-
-fn get_mock_result() -> VerifierData {
-    l1_data_to_verifier_data(get_mock_l1_data())
-}
-
-fn get_mock_result_serialized() -> Span<felt252> {
-    let mut result_serialized = array![];
-    get_mock_result().serialize(ref result_serialized);
-    result_serialized.span()
 }
 
 fn get_request(ref vault: VaultFacade) -> JobRequest {
@@ -69,22 +56,20 @@ fn get_request_serialized(ref vault: VaultFacade) -> Span<felt252> {
 #[available_gas(50000000)]
 fn test_only_pitchlake_verifier_can_call_fossil_callback() {
     let (mut vault, _) = setup_facade();
-
     accelerate_to_auctioning(ref vault);
     accelerate_to_running(ref vault);
     timeskip_to_settlement_date(ref vault);
 
-    let request = get_request_serialized(ref vault);
-    let result = get_mock_result_serialized();
+    let req = vault.get_request_to_settle_round_serialized();
+    let res = vault.generate_settle_round_result_serialized(get_mock_l1_data());
 
     // Should fail
     set_contract_address(contract_address_const::<'NOT IT'>());
-    // l1 data, timestamp, error
-    vault.fossil_callback_expect_error(request, result, vErrors::CallerNotVerifier);
+    vault.fossil_callback_expect_error(req, res, vErrors::CallerNotVerifier);
 
     // Should not fail
     set_contract_address(PITCHLAKE_VERIFIER());
-    vault.fossil_callback(request, result);
+    vault.fossil_callback(req, res);
 }
 
 // Test invalid request fails
@@ -96,13 +81,13 @@ fn test_invalid_request_fails() {
     accelerate_to_running(ref vault);
     timeskip_to_settlement_date(ref vault);
 
-    let mut request = get_request_serialized(ref vault);
-    let result = get_mock_result_serialized();
+    let mut req = vault.get_request_to_settle_round_serialized();
+    let res = vault.generate_settle_round_result_serialized(get_mock_l1_data());
 
     // Should fail
     set_contract_address(PITCHLAKE_VERIFIER());
-    let _ = request.pop_front();
-    vault.fossil_callback_expect_error(request, result, vErrors::FailedToDeserializeJobRequest);
+    let _ = req.pop_front();
+    vault.fossil_callback_expect_error(req, res, vErrors::FailedToDeserializeJobRequest);
 }
 
 // Test invalid Fossil result fails
@@ -114,13 +99,13 @@ fn test_invalid_result_fails() {
     accelerate_to_running(ref vault);
     timeskip_to_settlement_date(ref vault);
 
-    let request = get_request_serialized(ref vault);
-    let mut result = get_mock_result_serialized();
+    let req = vault.get_request_to_settle_round_serialized();
+    let mut res = vault.generate_settle_round_result_serialized(get_mock_l1_data());
 
     // Should fail
     set_contract_address(PITCHLAKE_VERIFIER());
-    let _ = result.pop_front();
-    vault.fossil_callback_expect_error(request, result, vErrors::FailedToDeserializeVerifierData);
+    let _ = res.pop_front();
+    vault.fossil_callback_expect_error(req, res, vErrors::FailedToDeserializeVerifierData);
 }
 
 // Test empty L1 data is not accepted
@@ -132,30 +117,19 @@ fn test_default_l1_data_fails() {
     accelerate_to_running(ref vault);
     timeskip_to_settlement_date(ref vault);
 
-    let mut request_serialized = array![];
-    let mut result1_serialized = array![];
-    let mut result2_serialized = array![];
-
-    vault.get_request_to_settle_round().serialize(ref request_serialized);
-
-    let mut result1 = get_mock_result();
-    let mut result2 = get_mock_result();
-
-    result1.twap_result = 0;
-    result2.reserve_price = 0;
-
-    result1.serialize(ref result1_serialized);
-    result2.serialize(ref result2_serialized);
+    let l1_data = L1Data { twap: 0, max_return: 1, reserve_price: 1 };
+    let req = vault.get_request_to_settle_round_serialized();
+    let res = vault.generate_settle_round_result_serialized(l1_data);
 
     // Should fail
-    vault
-        .fossil_callback_expect_error(
-            request_serialized.span(), result1_serialized.span(), vErrors::InvalidL1Data
-        );
-    vault
-        .fossil_callback_expect_error(
-            request_serialized.span(), result2_serialized.span(), vErrors::InvalidL1Data
-        );
+    vault.fossil_callback_expect_error(req, res, vErrors::InvalidL1Data);
+
+    let l1_data = L1Data { twap: 1, max_return: 1, reserve_price: 0 };
+    let req = vault.get_request_to_settle_round_serialized();
+    let res = vault.generate_settle_round_result_serialized(l1_data);
+
+    // Should fail
+    vault.fossil_callback_expect_error(req, res, vErrors::InvalidL1Data);
 }
 
 // Test callback event
@@ -170,10 +144,12 @@ fn test_callback_event() {
     timeskip_to_settlement_date(ref vault);
 
     set_contract_address(PITCHLAKE_VERIFIER());
-    let request = get_request_serialized(ref vault);
-    let result = get_mock_result_serialized();
+
+    let req = vault.get_request_to_settle_round_serialized();
+    let res = vault.generate_settle_round_result_serialized(get_mock_l1_data());
+
     clear_event_logs(array![vault.contract_address()]);
-    vault.fossil_callback(request, result);
+    vault.fossil_callback(req, res);
 
     assert_fossil_callback_success_event(
         vault.contract_address(), get_mock_l1_data(), current_round.get_option_settlement_date()
@@ -191,20 +167,19 @@ fn test_only_fossil_client_can_call_fossil_client_callback() {
     accelerate_to_running(ref vault);
     timeskip_to_settlement_date(ref vault);
 
-    let mut current_round = vault.get_current_round();
+    //let mut current_round = vault.get_current_round();
     let l1_data = get_mock_l1_data();
-    let settlement_date = current_round.get_option_settlement_date();
+    let req = vault.get_request_to_settle_round_serialized();
+    let res = vault.generate_settle_round_result_serialized(l1_data);
+    //let settlement_date = current_round.get_option_settlement_date();
 
     // Should fail
     set_contract_address(contract_address_const::<'NOT IT'>());
-    vault
-        .fossil_callback_expect_error_using_l1_data(
-            l1_data, settlement_date, vErrors::CallerNotVerifier
-        );
+    vault.fossil_callback_expect_error(req, res, vErrors::CallerNotVerifier);
 
     // Should not fail
     set_contract_address(vault.get_fossil_client_address());
-    vault.fossil_callback_using_l1_data(l1_data, settlement_date);
+    vault.fossil_callback(req, res);
 }
 
 // Test successfull callback sets the pricing data for the round
@@ -217,10 +192,10 @@ fn test_callback_sets_pricing_data_for_round() {
     timeskip_to_settlement_date(ref vault);
 
     // Settle round using callback data
-    let request = get_request_serialized(ref vault);
-    let result = get_mock_result_serialized();
+    let req = vault.get_request_to_settle_round_serialized();
+    let res = vault.generate_settle_round_result_serialized(get_mock_l1_data());
     set_contract_address(vault.get_fossil_client_address());
-    vault.fossil_callback(request, result);
+    vault.fossil_callback(req, res);
 
     // Check pricing data set as expected
     let mut current_round = vault.get_current_round();
@@ -235,29 +210,6 @@ fn test_callback_sets_pricing_data_for_round() {
     assert_eq!(current_round.get_reserve_price(), reserve_price);
 }
 
-// Test first callback fails if round is round not open
-#[test]
-#[available_gas(50000000)]
-#[ignore]
-// @note ignored for now, not sure we need this logic, first round's data can only be set if the
-// round is 1 and open, else fails
-fn test_first_round_callback_fails_if_now_is_auction_start_date() {
-    let eth_address = deploy_eth().contract_address;
-    let mut vault = VaultFacade { vault_dispatcher: deploy_vault(1234, 1234, eth_address) };
-    let mut current_round = vault.get_current_round();
-
-    let l1_data = get_mock_l1_data();
-    let settlement_date = current_round.get_deployment_date();
-
-    set_block_timestamp(current_round.get_auction_start_date());
-    set_contract_address(vault.get_fossil_client_address());
-    // Should fail
-    vault
-        .fossil_callback_expect_error_using_l1_data(
-            l1_data, settlement_date, vErrors::L1DataNotAcceptedNow
-        );
-}
-
 // Test callback fails if round > 1 is open
 #[test]
 #[available_gas(50000000)]
@@ -267,16 +219,12 @@ fn test_round_callback_fails_if_non_first_round_open() {
     accelerate_to_running(ref vault);
     accelerate_to_settled(ref vault, to_gwei(4));
 
-    let mut current_round = vault.get_current_round();
-    let l1_data = get_mock_l1_data();
-    let timestamp = current_round.get_deployment_date();
+    let req = vault.get_request_to_settle_round_serialized();
+    let res = vault.generate_settle_round_result_serialized(get_mock_l1_data());
 
     // Should fail
     set_contract_address(vault.get_fossil_client_address());
-    vault
-        .fossil_callback_expect_error_using_l1_data(
-            l1_data, timestamp, vErrors::L1DataNotAcceptedNow
-        );
+    vault.fossil_callback_expect_error(req, res, vErrors::L1DataNotAcceptedNow);
 }
 
 // Test callbacks fail if round is Auctioning
@@ -284,44 +232,44 @@ fn test_round_callback_fails_if_non_first_round_open() {
 #[available_gas(50000000)]
 fn test_callback_fails_if_current_round_auctioning() {
     let (mut vault, _) = setup_facade();
-    let mut current_round = vault.get_current_round();
     accelerate_to_auctioning(ref vault);
 
-    let l1_data = get_mock_l1_data();
-    let timestamp = current_round.get_deployment_date();
+    let req = vault.get_request_to_settle_round_serialized();
+    let res = vault.generate_settle_round_result_serialized(get_mock_l1_data());
 
     // Should fail
     set_contract_address(vault.get_fossil_client_address());
-    vault
-        .fossil_callback_expect_error_using_l1_data(
-            l1_data, timestamp, vErrors::L1DataNotAcceptedNow
-        );
+    vault.fossil_callback_expect_error(req, res, vErrors::L1DataNotAcceptedNow);
 }
 
 // Test callback can init first round if in range
 #[test]
 #[available_gas(50000000)]
 fn test_callback_for_first_round_if_in_range() {
+    set_block_timestamp(123456789);
     let eth_address = deploy_eth().contract_address;
     let mut vault = VaultFacade { vault_dispatcher: deploy_vault(1234, 1234, eth_address) };
+    set_block_timestamp(get_block_timestamp() + vault.get_proving_delay());
     let mut current_round = vault.get_current_round();
 
-    let L1Data { twap, max_return, reserve_price } = get_mock_l1_data();
-    let l1_data = L1Data { twap, max_return, reserve_price };
-    let deployment_date = current_round.get_deployment_date();
+    let l1_data = get_mock_l1_data();
+    let req = vault.get_request_to_start_first_round_serialized();
+    let res = vault.generate_first_round_result_serialized(l1_data);
 
-    set_block_timestamp(current_round.get_auction_start_date() - 1);
     set_contract_address(vault.get_fossil_client_address());
-    vault.fossil_callback_using_l1_data(l1_data, deployment_date);
 
-    let expected_strike = pricing_utils::calculate_strike_price(vault.get_strike_level(), twap);
+    vault.fossil_callback(req, res);
+
+    let expected_strike = pricing_utils::calculate_strike_price(
+        vault.get_strike_level(), l1_data.twap
+    );
     let expected_cap = pricing_utils::calculate_cap_level(
-        vault.get_alpha(), vault.get_strike_level(), max_return
+        vault.get_alpha(), vault.get_strike_level(), l1_data.max_return
     );
 
     assert_eq!(current_round.get_strike_price(), expected_strike);
     assert_eq!(current_round.get_cap_level(), expected_cap);
-    assert_eq!(current_round.get_reserve_price(), reserve_price);
+    assert_eq!(current_round.get_reserve_price(), l1_data.reserve_price);
 }
 
 
@@ -329,27 +277,24 @@ fn test_callback_for_first_round_if_in_range() {
 #[test]
 #[available_gas(50000000)]
 fn test_callback_out_of_range_fails_first_round_start() {
-    set_block_timestamp(123);
+    set_block_timestamp(123456789);
     let eth_address = deploy_eth().contract_address;
     let mut vault = VaultFacade { vault_dispatcher: deploy_vault(1234, 1234, eth_address) };
-    let mut current_round = vault.get_current_round();
+    set_block_timestamp(get_block_timestamp() + vault.get_proving_delay());
 
-    let L1Data { twap, max_return, reserve_price } = get_mock_l1_data();
-    let l1_data = L1Data { twap, max_return, reserve_price };
+    let mut current_round = vault.get_current_round();
     let deployment_date = current_round.get_deployment_date();
+
+    let req = vault.generate_custom_job_request_serialized(deployment_date - 1);
+    let req2 = vault.generate_custom_job_request_serialized(deployment_date + 1);
+    let res = vault.generate_settle_round_result_serialized(get_mock_l1_data());
 
     set_block_timestamp(current_round.get_auction_start_date() - 1);
     set_contract_address(vault.get_fossil_client_address());
 
     // Should fail
-    vault
-        .fossil_callback_expect_error_using_l1_data(
-            l1_data, deployment_date - 1, vErrors::L1DataOutOfRange
-        );
-    vault
-        .fossil_callback_expect_error_using_l1_data(
-            l1_data, deployment_date + 1, vErrors::L1DataOutOfRange
-        );
+    vault.fossil_callback_expect_error(req, res, vErrors::L1DataOutOfRange);
+    vault.fossil_callback_expect_error(req2, res, vErrors::L1DataOutOfRange);
 }
 
 // Test callback to settle a round fails if out of range
@@ -360,25 +305,19 @@ fn test_callback_out_of_range_fails_settle_current_round() {
     let mut current_round = vault.get_current_round();
     accelerate_to_auctioning(ref vault);
     accelerate_to_running(ref vault);
-
-    let L1Data { twap, max_return, reserve_price } = get_mock_l1_data();
-    let l1_data = L1Data { twap, max_return, reserve_price };
     let settlement_date = current_round.get_option_settlement_date();
+
+    let req = vault.generate_custom_job_request_serialized(settlement_date - 1);
+    let req2 = vault.generate_custom_job_request_serialized(settlement_date + 1);
+    let res = vault.generate_settle_round_result_serialized(get_mock_l1_data());
 
     set_block_timestamp(current_round.get_auction_start_date() - 1);
     set_contract_address(vault.get_fossil_client_address());
 
     // Should fail
-    vault
-        .fossil_callback_expect_error_using_l1_data(
-            l1_data, settlement_date + 1, vErrors::L1DataOutOfRange
-        );
-    vault
-        .fossil_callback_expect_error_using_l1_data(
-            l1_data, settlement_date - 1, vErrors::L1DataOutOfRange
-        );
+    vault.fossil_callback_expect_error(req, res, vErrors::L1DataOutOfRange);
+    vault.fossil_callback_expect_error(req2, res, vErrors::L1DataOutOfRange);
 }
-
 
 // Test callback settles round and deploys next correctly
 #[test]
@@ -391,9 +330,10 @@ fn test_callback_works_as_expected() {
     timeskip_to_settlement_date(ref vault);
 
     // Callback/settle round
-    let request = get_request_serialized(ref vault);
-    let result = get_mock_result_serialized();
-    vault.fossil_callback(request, result);
+    let req = vault.get_request_to_settle_round_serialized();
+    let res = vault.generate_settle_round_result_serialized(get_mock_l1_data());
+
+    vault.fossil_callback(req, res);
 
     let mut next_round = vault.get_current_round();
     let l1_data = get_mock_l1_data();

--- a/src/tests/option_round/state_transition/fulfill_request_tests.cairo
+++ b/src/tests/option_round/state_transition/fulfill_request_tests.cairo
@@ -1,37 +1,31 @@
-use starknet::{
-    get_block_timestamp, ContractAddress, contract_address_const,
-    testing::{set_contract_address, set_block_timestamp}
+use pitch_lake::library::pricing_utils;
+use pitch_lake::library::pricing_utils::calculate_strike_price;
+use pitch_lake::option_round::interface::PricingData;
+use pitch_lake::tests::utils::facades::option_round_facade::{
+    OptionRoundFacade, OptionRoundFacadeTrait,
 };
-use pitch_lake::{
-    vault::interface::{VerifierData, JobRequest, L1Data}, vault::contract::Vault,
-    vault::contract::Vault::{Errors as vErrors}, option_round::interface::PricingData,
-    library::pricing_utils,
-    tests::{
-        utils::{
-            lib::{test_accounts::{liquidity_provider_1,}},
-            helpers::{
-                accelerators::{
-                    accelerate_to_auctioning, accelerate_to_auctioning_custom,
-                    accelerate_to_running_custom, accelerate_to_running,
-                    accelerate_to_settled_custom, timeskip_to_settlement_date, accelerate_to_settled
-                },
-                setup::{
-                    eth_supply_and_approve_all_providers, eth_supply_and_approve_all_bidders,
-                    deploy_eth, deploy_vault, setup_facade, PITCHLAKE_VERIFIER
-                },
-                event_helpers::{clear_event_logs, assert_fossil_callback_success_event},
-                general_helpers::{to_gwei},
-            },
-            facades::{
-                vault_facade::{VaultFacadeImpl, VaultFacade, VaultFacadeTrait},
-                option_round_facade::{OptionRoundFacade, OptionRoundFacadeTrait},
-            },
-        },
-    }
+use pitch_lake::tests::utils::facades::vault_facade::{
+    VaultFacade, VaultFacadeImpl, VaultFacadeTrait,
 };
-
-use pitch_lake::library::pricing_utils::{calculate_strike_price};
-use core::integer::{I128Neg};
+use pitch_lake::tests::utils::helpers::accelerators::{
+    accelerate_to_auctioning, accelerate_to_auctioning_custom, accelerate_to_running,
+    accelerate_to_running_custom, accelerate_to_settled, accelerate_to_settled_custom,
+    timeskip_to_settlement_date,
+};
+use pitch_lake::tests::utils::helpers::event_helpers::{
+    assert_fossil_callback_success_event, clear_event_logs,
+};
+use pitch_lake::tests::utils::helpers::general_helpers::to_gwei;
+use pitch_lake::tests::utils::helpers::setup::{
+    PITCHLAKE_VERIFIER, deploy_eth, deploy_vault, eth_supply_and_approve_all_bidders,
+    eth_supply_and_approve_all_providers, setup_facade,
+};
+use pitch_lake::tests::utils::lib::test_accounts::liquidity_provider_1;
+use pitch_lake::vault::contract::Vault;
+use pitch_lake::vault::contract::Vault::Errors as vErrors;
+use pitch_lake::vault::interface::{JobRequest, L1Data, VerifierData};
+use starknet::testing::{set_block_timestamp, set_contract_address};
+use starknet::{ContractAddress, contract_address_const, get_block_timestamp};
 
 
 fn get_mock_l1_data() -> L1Data {
@@ -152,7 +146,7 @@ fn test_callback_event() {
     vault.fossil_callback(req, res);
 
     assert_fossil_callback_success_event(
-        vault.contract_address(), get_mock_l1_data(), current_round.get_option_settlement_date()
+        vault.contract_address(), get_mock_l1_data(), current_round.get_option_settlement_date(),
     );
 }
 
@@ -202,7 +196,7 @@ fn test_callback_sets_pricing_data_for_round() {
     let L1Data { twap, max_return, reserve_price } = get_mock_l1_data();
     let exp_strike_price = pricing_utils::calculate_strike_price(vault.get_strike_level(), twap);
     let exp_cap_level = pricing_utils::calculate_cap_level(
-        vault.get_alpha(), vault.get_strike_level(), max_return
+        vault.get_alpha(), vault.get_strike_level(), max_return,
     );
 
     assert_eq!(current_round.get_strike_price(), exp_strike_price);
@@ -261,10 +255,10 @@ fn test_callback_for_first_round_if_in_range() {
     vault.fossil_callback(req, res);
 
     let expected_strike = pricing_utils::calculate_strike_price(
-        vault.get_strike_level(), l1_data.twap
+        vault.get_strike_level(), l1_data.twap,
     );
     let expected_cap = pricing_utils::calculate_cap_level(
-        vault.get_alpha(), vault.get_strike_level(), l1_data.max_return
+        vault.get_alpha(), vault.get_strike_level(), l1_data.max_return,
     );
 
     assert_eq!(current_round.get_strike_price(), expected_strike);
@@ -339,7 +333,7 @@ fn test_callback_works_as_expected() {
     let l1_data = get_mock_l1_data();
     let strike = pricing_utils::calculate_strike_price(vault.get_strike_level(), l1_data.twap);
     let cap = pricing_utils::calculate_cap_level(
-        vault.get_alpha(), vault.get_strike_level(), l1_data.max_return
+        vault.get_alpha(), vault.get_strike_level(), l1_data.max_return,
     );
 
     assert_eq!(next_round.get_cap_level(), cap);

--- a/src/tests/option_round/state_transition/option_settle/calculated_payout_tests.cairo
+++ b/src/tests/option_round/state_transition/option_settle/calculated_payout_tests.cairo
@@ -1,24 +1,18 @@
-use pitch_lake::{
-    library::utils::{min, max}, library::constants::{BPS_u256},
-    tests::{
-        utils::{
-            helpers::{
-                setup::{setup_facade, setup_test_running},
-                accelerators::{
-                    accelerate_to_auctioning, accelerate_to_running, accelerate_to_settled
-                },
-            },
-            lib::{test_accounts::{option_bidder_buyer_1}, variables::{bps},},
-            facades::{
-                vault_facade::{VaultFacade, VaultFacadeTrait},
-                option_round_facade::{OptionRoundFacade, OptionRoundFacadeTrait}
-            },
-        },
-    }
+use pitch_lake::library::constants::BPS_u256;
+use pitch_lake::library::utils::{max, min};
+use pitch_lake::tests::utils::facades::option_round_facade::{
+    OptionRoundFacade, OptionRoundFacadeTrait,
 };
+use pitch_lake::tests::utils::facades::vault_facade::{VaultFacade, VaultFacadeTrait};
+use pitch_lake::tests::utils::helpers::accelerators::{
+    accelerate_to_auctioning, accelerate_to_running, accelerate_to_settled,
+};
+use pitch_lake::tests::utils::helpers::setup::{setup_facade, setup_test_running};
+use pitch_lake::tests::utils::lib::test_accounts::option_bidder_buyer_1;
+use pitch_lake::tests::utils::lib::variables::bps;
 
 
-fn calculate_expected_payout(ref round: OptionRoundFacade, settlement_price: u256,) -> u256 {
+fn calculate_expected_payout(ref round: OptionRoundFacade, settlement_price: u256) -> u256 {
     let strike_price = round.get_strike_price();
     let cap_level = round.get_cap_level();
     let max_payout_per_option = (cap_level.into() * strike_price) / BPS_u256;

--- a/src/tests/pitchlake_verifier/verifier_tests.cairo
+++ b/src/tests/pitchlake_verifier/verifier_tests.cairo
@@ -6,7 +6,7 @@ use pitch_lake::tests::utils::helpers::setup::{PITCHLAKE_VERIFIER};
 use openzeppelin_access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};
 use openzeppelin_access::ownable::{OwnableComponent::Errors as OErrors};
 use pitch_lake::{
-    library::{eth::Eth, constants::PROGRAM_ID}, vault::interface::{JobRequest, VerifierData},
+    library::{eth::Eth}, vault::interface::{JobRequest, VerifierData},
     vault::{
         contract::Vault::L1Data,
         interface::{

--- a/src/tests/pitchlake_verifier/verifier_tests.cairo
+++ b/src/tests/pitchlake_verifier/verifier_tests.cairo
@@ -87,17 +87,17 @@ fn test_job_request_deserialization() {
 #[test]
 fn test_verifier_serialization() {
     let verifier_data = VerifierData {
-        start_timestamp: 1000,
-        end_timestamp: 2000,
+        reserve_price_start_timestamp: 1000,
+        reserve_price_end_timestamp: 2000,
         reserve_price: 3000,
-        //        floating_point_tolerance: 10,
-        //        reserve_price_tolerance: 20,
-        //        twap_tolerance: 30,
-        //        gradient_tolerance: 40,
-        twap_result: 5000,
-        max_return: 6000
+        twap_start_timestamp: 4000,
+        twap_end_timestamp: 5000,
+        twap_result: 6000,
+        max_return_start_timestamp: 7000,
+        max_return_end_timestamp: 8000,
+        max_return: 9000
     };
-    let mut serialized_span = array![1000, 2000, 3000, 5000, 6000].span();
+    let mut serialized_span = array![1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000].span();
 
     // Test serialize
     let mut serialized: Array<felt252> = array![];
@@ -108,17 +108,17 @@ fn test_verifier_serialization() {
 #[test]
 fn test_verifier_deserialization() {
     let verifier_data = VerifierData {
-        start_timestamp: 1000,
-        end_timestamp: 2000,
+        reserve_price_start_timestamp: 1000,
+        reserve_price_end_timestamp: 2000,
         reserve_price: 3000,
-        //        floating_point_tolerance: 10,
-        //        reserve_price_tolerance: 20,
-        //        twap_tolerance: 30,
-        //        gradient_tolerance: 40,
-        twap_result: 5000,
-        max_return: 6000
+        twap_start_timestamp: 4000,
+        twap_end_timestamp: 5000,
+        twap_result: 6000,
+        max_return_start_timestamp: 7000,
+        max_return_end_timestamp: 8000,
+        max_return: 9000
     };
-    let mut serialized_span = array![1000, 2000, 3000, 5000, 6000].span();
+    let mut serialized_span = array![1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000].span();
 
     // Test deserialize
     let deserialized: VerifierData = Serde::deserialize(ref serialized_span)
@@ -136,11 +136,11 @@ fn test_caller_not_verifier_fossil_callback() {
 
     starknet::testing::set_contract_address('not verifier'.try_into().unwrap());
 
-    vault
-        .fossil_callback_expect_error_using_l1_data(
-            L1Data { twap: to_gwei(3000), max_return: 5000, reserve_price: to_gwei(2000) },
-            1234,
-            Errors::CallerNotVerifier
-        );
+    let l1_data = L1Data { twap: to_gwei(1111), max_return: 2222, reserve_price: to_gwei(3333) };
+
+    let request = vault.get_request_to_settle_round_serialized();
+    let result = vault.generate_job_result_serialized_from_l1_data_custom(l1_data);
+
+    vault.fossil_callback_expect_error(request, result, Errors::CallerNotVerifier);
 }
 

--- a/src/tests/pitchlake_verifier/verifier_tests.cairo
+++ b/src/tests/pitchlake_verifier/verifier_tests.cairo
@@ -1,57 +1,11 @@
-use pitch_lake::vault::contract::Vault::Errors;
-use pitch_lake::tests::utils::helpers::setup::{PITCHLAKE_VERIFIER};
-//use pitch_lake::tests::utils::facades::fossil_client_facade::{
-//    FossilClientFacade, FossilClientFacadeTrait
-//};
-use openzeppelin_access::ownable::interface::{IOwnableDispatcher, IOwnableDispatcherTrait};
-use openzeppelin_access::ownable::{OwnableComponent::Errors as OErrors};
-use pitch_lake::{
-    library::{eth::Eth}, vault::interface::{JobRequest, VerifierData},
-    vault::{
-        contract::Vault::L1Data,
-        interface::{
-            IVaultDispatcher, IVaultSafeDispatcher, IVaultDispatcherTrait,
-            IVaultSafeDispatcherTrait,
-        }
-    },
-    option_round::contract::OptionRound::Errors as rErrors, option_round::interface::PricingData,
-    tests::{
-        utils::{
-            helpers::{
-                general_helpers::{
-                    get_portion_of_amount, create_array_linear, create_array_gradient,
-                    get_erc20_balances, sum_u256_array, to_gwei,
-                },
-                event_helpers::{
-                    clear_event_logs, assert_event_option_settle, assert_event_transfer,
-                    assert_no_events_left, pop_log, assert_event_option_round_deployed_single,
-                    assert_event_option_round_deployed,
-                },
-                accelerators::{
-                    timeskip_to_settlement_date, accelerate_to_auctioning, accelerate_to_running,
-                    accelerate_to_settled, accelerate_to_auctioning_custom,
-                    accelerate_to_running_custom
-                },
-                setup::{
-                    deploy_vault_with_events, setup_facade, setup_test_auctioning_providers,
-                    setup_test_running, AUCTION_DURATION, ROUND_TRANSITION_DURATION, ROUND_DURATION
-                },
-            },
-            lib::{
-                test_accounts::{
-                    liquidity_provider_1, liquidity_provider_2, option_bidder_buyer_1,
-                    option_bidder_buyer_2, option_bidder_buyer_3, option_bidder_buyer_4,
-                    liquidity_providers_get, liquidity_provider_3, liquidity_provider_4,
-                },
-                variables::{decimals},
-            },
-            facades::{
-                vault_facade::{VaultFacade, VaultFacadeTrait},
-                option_round_facade::{OptionRoundState, OptionRoundFacade, OptionRoundFacadeTrait},
-            },
-        },
-    }
+use pitch_lake::tests::utils::facades::vault_facade::VaultFacadeTrait;
+use pitch_lake::tests::utils::helpers::accelerators::{
+    accelerate_to_auctioning, accelerate_to_running, timeskip_to_settlement_date,
 };
+use pitch_lake::tests::utils::helpers::general_helpers::to_gwei;
+use pitch_lake::tests::utils::helpers::setup::setup_facade;
+use pitch_lake::vault::contract::Vault::Errors;
+use pitch_lake::vault::interface::{JobRequest, L1Data, VerifierData};
 
 // TODO: Change these after verifier cleanup
 
@@ -92,7 +46,7 @@ fn test_verifier_serialization() {
         twap_result: 6000,
         max_return_start_timestamp: 7000,
         max_return_end_timestamp: 8000,
-        max_return: 9000
+        max_return: 9000,
     };
     let mut serialized_span = array![1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000].span();
 
@@ -113,7 +67,7 @@ fn test_verifier_deserialization() {
         twap_result: 6000,
         max_return_start_timestamp: 7000,
         max_return_end_timestamp: 8000,
-        max_return: 9000
+        max_return: 9000,
     };
     let mut serialized_span = array![1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000].span();
 
@@ -140,4 +94,3 @@ fn test_caller_not_verifier_fossil_callback() {
 
     vault.fossil_callback_expect_error(request, result, Errors::CallerNotVerifier);
 }
-

--- a/src/tests/pitchlake_verifier/verifier_tests.cairo
+++ b/src/tests/pitchlake_verifier/verifier_tests.cairo
@@ -46,10 +46,7 @@ use pitch_lake::{
                 variables::{decimals},
             },
             facades::{
-                vault_facade::{
-                    l1_data_to_verifier_data_serialized, l1_data_to_verifier_data, VaultFacade,
-                    VaultFacadeTrait
-                },
+                vault_facade::{VaultFacade, VaultFacadeTrait},
                 option_round_facade::{OptionRoundState, OptionRoundFacade, OptionRoundFacadeTrait},
             },
         },
@@ -139,7 +136,7 @@ fn test_caller_not_verifier_fossil_callback() {
     let l1_data = L1Data { twap: to_gwei(1111), max_return: 2222, reserve_price: to_gwei(3333) };
 
     let request = vault.get_request_to_settle_round_serialized();
-    let result = vault.generate_job_result_serialized_from_l1_data_custom(l1_data);
+    let result = vault.generate_custom_job_result_from_l1_data_serialized(l1_data);
 
     vault.fossil_callback_expect_error(request, result, Errors::CallerNotVerifier);
 }

--- a/src/tests/utils/facades/option_round_facade.cairo
+++ b/src/tests/utils/facades/option_round_facade.cairo
@@ -1,48 +1,40 @@
 //Helper functions for posterity
 use openzeppelin_token::erc20::interface::{ERC20ABIDispatcher, ERC20ABIDispatcherTrait};
-use starknet::{ContractAddress, testing::{set_contract_address}};
-use pitch_lake::{
-    types::{Errors, Bid}, library::constants::BPS_u256,
-    option_round::{
-        interface::{
-            OptionRoundState, IOptionRoundDispatcher, IOptionRoundDispatcherTrait,
-            IOptionRoundSafeDispatcher, IOptionRoundSafeDispatcherTrait, PricingData
-        }
-    },
-    vault::{
-        interface::{
-            IVaultDispatcher, IVaultSafeDispatcher, IVaultDispatcherTrait,
-            IVaultSafeDispatcherTrait,
-        },
-        contract::Vault,
-    },
-    tests::{
-        utils::{
-            helpers::{
-                setup::eth_supply_and_approve_all_bidders,
-                general_helpers::{to_gwei, assert_two_arrays_equal_length, get_erc20_balance},
-                accelerators::{accelerate_to_auctioning_custom},
-            },
-            lib::{test_accounts::{vault_manager, bystander, liquidity_provider_1},},
-            facades::{sanity_checks, vault_facade::{VaultFacade, VaultFacadeTrait},},
-        }
-    },
+use pitch_lake::library::constants::BPS_u256;
+use pitch_lake::option_round::interface::{
+    IOptionRoundDispatcher, IOptionRoundDispatcherTrait, IOptionRoundSafeDispatcher,
+    IOptionRoundSafeDispatcherTrait, OptionRoundState, PricingData,
 };
+use pitch_lake::tests::utils::facades::sanity_checks;
+use pitch_lake::tests::utils::facades::vault_facade::{VaultFacade, VaultFacadeTrait};
+use pitch_lake::tests::utils::helpers::accelerators::accelerate_to_auctioning_custom;
+use pitch_lake::tests::utils::helpers::general_helpers::{
+    assert_two_arrays_equal_length, get_erc20_balance, to_gwei,
+};
+use pitch_lake::tests::utils::helpers::setup::eth_supply_and_approve_all_bidders;
+use pitch_lake::tests::utils::lib::test_accounts::{bystander, liquidity_provider_1, vault_manager};
+use pitch_lake::types::{Bid, Errors};
+use pitch_lake::vault::contract::Vault;
+use pitch_lake::vault::interface::{
+    IVaultDispatcher, IVaultDispatcherTrait, IVaultSafeDispatcher, IVaultSafeDispatcherTrait,
+};
+use starknet::ContractAddress;
+use starknet::testing::set_contract_address;
 
 #[derive(Drop)]
-struct OptionRoundFacade {
-    option_round_dispatcher: IOptionRoundDispatcher,
+pub struct OptionRoundFacade {
+    pub option_round_dispatcher: IOptionRoundDispatcher,
 }
 
 #[generate_trait]
-impl OptionRoundFacadeImpl of OptionRoundFacadeTrait {
+pub impl OptionRoundFacadeImpl of OptionRoundFacadeTrait {
     fn get_safe_dispatcher(ref self: OptionRoundFacade) -> IOptionRoundSafeDispatcher {
         IOptionRoundSafeDispatcher { contract_address: self.contract_address() }
     }
 
     fn get_vault_facade(ref self: OptionRoundFacade) -> VaultFacade {
         VaultFacade {
-            vault_dispatcher: IVaultDispatcher { contract_address: self.vault_address() }
+            vault_dispatcher: IVaultDispatcher { contract_address: self.vault_address() },
         }
     }
 
@@ -60,7 +52,7 @@ impl OptionRoundFacadeImpl of OptionRoundFacadeTrait {
 
     #[feature("safe_dispatcher")]
     fn set_pricing_data_expect_err(
-        ref self: OptionRoundFacade, pricing_data: PricingData, error: felt252
+        ref self: OptionRoundFacade, pricing_data: PricingData, error: felt252,
     ) {
         let safe = self.get_safe_dispatcher();
         safe.set_pricing_data(pricing_data).expect_err(error);
@@ -84,14 +76,14 @@ impl OptionRoundFacadeImpl of OptionRoundFacadeTrait {
         let starting_liquidity = (options_available * capped_payout_per_option);
 
         // Update the params of the option round
-        let pricing_data = PricingData { strike_price, cap_level, reserve_price, };
+        let pricing_data = PricingData { strike_price, cap_level, reserve_price };
 
         // Update the pricing data points as the Vault
         set_contract_address(vault.contract_address());
         self.set_pricing_data(pricing_data);
 
         let total_options_available = accelerate_to_auctioning_custom(
-            ref vault, array![liquidity_provider_1()].span(), array![starting_liquidity].span()
+            ref vault, array![liquidity_provider_1()].span(), array![starting_liquidity].span(),
         );
 
         assert(total_options_available == options_available, 'options available mismatch');
@@ -180,9 +172,9 @@ impl OptionRoundFacadeImpl of OptionRoundFacadeTrait {
                     // Append result
                     results.append(bid_id);
                 },
-                Option::None => { break (); }
+                Option::None => { break (); },
             }
-        };
+        }
         results
     }
 
@@ -223,10 +215,10 @@ impl OptionRoundFacadeImpl of OptionRoundFacadeTrait {
                     set_contract_address(*bidder);
                     match safe_option_round.place_bid(*bid_amount, *bid_price) {
                         Result::Ok(_) => {},
-                        Result::Err(_) => {}
+                        Result::Err(_) => {},
                     }
                 },
-                Option::None => { break (); }
+                Option::None => { break (); },
             }
         }
     }
@@ -255,7 +247,7 @@ impl OptionRoundFacadeImpl of OptionRoundFacadeTrait {
                     // Make bid
                     safe_option_round.place_bid(*bid_amount, *bid_price).expect_err(*error);
                 },
-                Option::None => { break (); }
+                Option::None => { break (); },
             }
         };
     }
@@ -310,9 +302,9 @@ impl OptionRoundFacadeImpl of OptionRoundFacadeTrait {
                     let refund_amount = self.refund_bid(*bidder);
                     refund_amounts.append(refund_amount)
                 },
-                Option::None => { break (); }
+                Option::None => { break (); },
             }
-        };
+        }
         refund_amounts
     }
 
@@ -338,15 +330,15 @@ impl OptionRoundFacadeImpl of OptionRoundFacadeTrait {
     // Exercise options for multiple option buyers
     // @return: The payout amounts
     fn exercise_options_multiple(
-        ref self: OptionRoundFacade, mut bidders: Span<ContractAddress>
+        ref self: OptionRoundFacade, mut bidders: Span<ContractAddress>,
     ) -> Array<u256> {
         let mut payouts = array![];
         loop {
             match bidders.pop_front() {
                 Option::Some(bidder) => { payouts.append(self.exercise_options(*bidder)); },
-                Option::None => { break (); }
+                Option::None => { break (); },
             }
-        };
+        }
         payouts
     }
 
@@ -355,7 +347,7 @@ impl OptionRoundFacadeImpl of OptionRoundFacadeTrait {
     fn mint_options(ref self: OptionRoundFacade, option_bidder_buyer: ContractAddress) -> u256 {
         set_contract_address(option_bidder_buyer);
         let option_erc20_balance_before = get_erc20_balance(
-            self.contract_address(), option_bidder_buyer
+            self.contract_address(), option_bidder_buyer,
         );
         let options_minted = self.option_round_dispatcher.mint_options();
         sanity_checks::tokenize_options(
@@ -429,7 +421,7 @@ impl OptionRoundFacadeImpl of OptionRoundFacadeTrait {
     }
 
     fn get_bidding_nonce_for(
-        ref self: OptionRoundFacade, option_bidder_buyer: ContractAddress
+        ref self: OptionRoundFacade, option_bidder_buyer: ContractAddress,
     ) -> u64 {
         self.option_round_dispatcher.get_account_bid_nonce(option_bidder_buyer)
     }
@@ -440,25 +432,25 @@ impl OptionRoundFacadeImpl of OptionRoundFacadeTrait {
 
 
     fn get_bids_for(
-        ref self: OptionRoundFacade, option_bidder_buyer: ContractAddress
+        ref self: OptionRoundFacade, option_bidder_buyer: ContractAddress,
     ) -> Array<Bid> {
         self.option_round_dispatcher.get_account_bids(option_bidder_buyer)
     }
 
     fn get_refundable_balance_for(
-        ref self: OptionRoundFacade, option_bidder_buyer: ContractAddress
+        ref self: OptionRoundFacade, option_bidder_buyer: ContractAddress,
     ) -> u256 {
         self.option_round_dispatcher.get_account_refundable_balance(option_bidder_buyer)
     }
 
     fn get_payout_balance_for(
-        ref self: OptionRoundFacade, option_bidder_buyer: ContractAddress
+        ref self: OptionRoundFacade, option_bidder_buyer: ContractAddress,
     ) -> u256 {
         self.option_round_dispatcher.get_account_payout_balance(option_bidder_buyer)
     }
 
     fn get_mintable_options_for(
-        ref self: OptionRoundFacade, option_bidder_buyer: ContractAddress
+        ref self: OptionRoundFacade, option_bidder_buyer: ContractAddress,
     ) -> u256 {
         self.option_round_dispatcher.get_account_mintable_options(option_bidder_buyer)
     }

--- a/src/tests/utils/facades/sanity_checks.cairo
+++ b/src/tests/utils/facades/sanity_checks.cairo
@@ -1,39 +1,24 @@
-use starknet::{ContractAddress, testing::{set_contract_address}};
-use openzeppelin_token::erc20::interface::{ERC20ABIDispatcherTrait,};
-use pitch_lake::{
-    types::Bid, option_round::{interface::IOptionRoundDispatcherTrait},
-    tests::{
-        utils::{
-            helpers::{
-                event_helpers,
-                accelerators::{
-                    accelerate_to_auctioning, accelerate_to_running, accelerate_to_running_custom,
-                    accelerate_to_settled,
-                },
-                general_helpers::{get_erc20_balance}, setup::{setup_facade},
-            },
-            lib::test_accounts::{option_bidders_get, liquidity_provider_1, liquidity_provider_2},
-            facades::{
-                vault_facade::{VaultFacade, VaultFacadeTrait},
-                option_round_facade::{OptionRoundFacade, OptionRoundFacadeTrait}
-            },
-        }
-    }
+use pitch_lake::tests::utils::facades::option_round_facade::{
+    OptionRoundFacade, OptionRoundFacadeTrait,
 };
+use pitch_lake::tests::utils::facades::vault_facade::{VaultFacade, VaultFacadeTrait};
+use pitch_lake::tests::utils::helpers::general_helpers::get_erc20_balance;
+use pitch_lake::types::Bid;
+use starknet::ContractAddress;
 
 
 /// Sanity checks ///
 // These ensure the returned values from write functions match their associated storage slot/getter
 // @note Commented out to avoid all tests failing for these reasons for now
 
-fn start_auction(ref option_round: OptionRoundFacade, total_options_available: u256) -> u256 {
+pub fn start_auction(ref option_round: OptionRoundFacade, total_options_available: u256) -> u256 {
     let expected = option_round.get_total_options_available();
     assert(expected == total_options_available, 'Auction start sanity check fail');
     total_options_available
 }
 
-fn end_auction(
-    ref option_round: OptionRoundFacade, clearing_price: u256, total_options_sold: u256
+pub fn end_auction(
+    ref option_round: OptionRoundFacade, clearing_price: u256, total_options_sold: u256,
 ) -> (u256, u256) {
     let expected1 = option_round.get_auction_clearing_price();
     let expected2 = option_round.total_options_sold();
@@ -42,49 +27,51 @@ fn end_auction(
     (clearing_price, total_options_sold)
 }
 
-fn settle_option_round(ref option_round: OptionRoundFacade, total_payout: u256) -> u256 {
+pub fn settle_option_round(ref option_round: OptionRoundFacade, total_payout: u256) -> u256 {
     let expected = option_round.total_payout();
     assert(expected == total_payout, 'Settle round sanity check fail');
     total_payout
 }
 
-fn refund_bid(ref option_round: OptionRoundFacade, refund_amount: u256, expected: u256) -> u256 {
+pub fn refund_bid(
+    ref option_round: OptionRoundFacade, refund_amount: u256, expected: u256,
+) -> u256 {
     assert(refund_amount == expected, 'Refund sanity check fail');
     refund_amount
 }
 
-fn exercise_options(
-    ref option_round: OptionRoundFacade, individual_payout: u256, expected: u256
+pub fn exercise_options(
+    ref option_round: OptionRoundFacade, individual_payout: u256, expected: u256,
 ) -> u256 {
     assert(individual_payout == expected, 'Exercise opts sanity check fail');
     individual_payout
 }
 
-fn place_bid(ref self: OptionRoundFacade, bid: Bid) -> Bid {
+pub fn place_bid(ref self: OptionRoundFacade, bid: Bid) -> Bid {
     let nonce: felt252 = (self.get_bidding_nonce_for(bid.owner) - 1).into();
-    let expected_id = poseidon::poseidon_hash_span(array![bid.owner.into(), nonce].span());
+    let expected_id = core::poseidon::poseidon_hash_span(array![bid.owner.into(), nonce].span());
     assert(bid.bid_id == expected_id, 'Invalid hash generated');
     bid
 }
 
-fn update_bid(ref option_round: OptionRoundFacade, old_bid: Bid, new_bid: Bid) -> Bid {
+pub fn update_bid(ref option_round: OptionRoundFacade, old_bid: Bid, new_bid: Bid) -> Bid {
     let storage_bid = option_round.get_bid_details(old_bid.bid_id);
     assert(new_bid == storage_bid, 'Bid Mismatch');
     new_bid
 }
 
-fn tokenize_options(
+pub fn tokenize_options(
     ref option_round: OptionRoundFacade,
     option_bidder: ContractAddress,
     option_erc20_balance_before: u256,
-    options_minted: u256
+    options_minted: u256,
 ) -> u256 {
     let option_erc20_balance_after = get_erc20_balance(
-        option_round.contract_address(), option_bidder
+        option_round.contract_address(), option_bidder,
     );
     assert(
         option_erc20_balance_after == option_erc20_balance_before + options_minted,
-        'ERC20 Balance Mismatch'
+        'ERC20 Balance Mismatch',
     );
     options_minted
 }
@@ -92,8 +79,8 @@ fn tokenize_options(
 
 /// Vault
 
-fn deposit(
-    ref vault: VaultFacade, liquidity_provider: ContractAddress, unlocked_amount: u256
+pub fn deposit(
+    ref vault: VaultFacade, liquidity_provider: ContractAddress, unlocked_amount: u256,
 ) -> u256 {
     let storage_unlocked_amount = vault.get_lp_unlocked_balance(liquidity_provider);
 
@@ -101,15 +88,15 @@ fn deposit(
     storage_unlocked_amount
 }
 
-fn withdraw(
-    ref vault: VaultFacade, liquidity_provider: ContractAddress, unlocked_amount: u256
+pub fn withdraw(
+    ref vault: VaultFacade, liquidity_provider: ContractAddress, unlocked_amount: u256,
 ) -> u256 {
     let unlocked_amount_in_storage = vault.get_lp_unlocked_balance(liquidity_provider);
     assert_eq!(unlocked_amount, unlocked_amount_in_storage);
     unlocked_amount_in_storage
 }
 
-fn claim_queued_liquidity(ref vault: VaultFacade, queued_amount: u256, expected: u256) -> u256 {
+pub fn claim_queued_liquidity(ref vault: VaultFacade, queued_amount: u256, expected: u256) -> u256 {
     assert!(queued_amount == expected, "Withdraw stashed sanity check fail");
     queued_amount
 }

--- a/src/tests/utils/facades/vault_facade.cairo
+++ b/src/tests/utils/facades/vault_facade.cairo
@@ -1,34 +1,18 @@
-use core::fmt::{Display, Error, Formatter};
 use fp::{UFixedPoint123x128, UFixedPoint123x128Impl};
-use starknet::{ContractAddress, testing::{set_contract_address, set_block_timestamp}};
-use openzeppelin_token::erc20::interface::{ERC20ABIDispatcher, ERC20ABIDispatcherTrait};
-use pitch_lake::{
-    vault::{
-        contract::Vault::{L1Data},
-        interface::{
-            VerifierData, IVaultDispatcher, IVaultDispatcherTrait, IVaultSafeDispatcher, JobRequest,
-            IVaultSafeDispatcherTrait
-        }
-    },
-    option_round::{
-        contract::OptionRound, interface::{IOptionRoundDispatcher, IOptionRoundDispatcherTrait,}
-    },
-    tests::{
-        utils::{
-            lib::{
-                test_accounts::{vault_manager, liquidity_provider_1, bystander},
-                variables::{decimals},
-            },
-            facades::{
-                option_round_facade::{OptionRoundFacade, OptionRoundFacadeTrait}, sanity_checks,
-            },
-            helpers::{
-                setup::{eth_supply_and_approve_all_bidders},
-                general_helpers::{assert_two_arrays_equal_length, to_gwei}
-            },
-        },
-    }
+use pitch_lake::option_round::interface::{IOptionRoundDispatcher, IOptionRoundDispatcherTrait};
+use pitch_lake::tests::utils::facades::option_round_facade::{
+    OptionRoundFacade, OptionRoundFacadeTrait,
 };
+use pitch_lake::tests::utils::facades::sanity_checks;
+use pitch_lake::tests::utils::helpers::general_helpers::{assert_two_arrays_equal_length, to_gwei};
+use pitch_lake::tests::utils::helpers::setup::eth_supply_and_approve_all_bidders;
+use pitch_lake::tests::utils::lib::test_accounts::bystander;
+use pitch_lake::vault::interface::{
+    IVaultDispatcher, IVaultDispatcherTrait, IVaultSafeDispatcher, IVaultSafeDispatcherTrait,
+    JobRequest, L1Data,
+};
+use starknet::ContractAddress;
+use starknet::testing::set_contract_address;
 
 fn pow(base: u256, exp: u256) -> u256 {
     if exp == 0_u256 {
@@ -39,13 +23,13 @@ fn pow(base: u256, exp: u256) -> u256 {
     while e > 0_u256 {
         result = result * base;
         e = e - 1_u256;
-    };
+    }
     result
 }
 
 #[derive(Drop, Copy)]
-struct VaultFacade {
-    vault_dispatcher: IVaultDispatcher,
+pub struct VaultFacade {
+    pub vault_dispatcher: IVaultDispatcher,
 }
 
 // 1234_u256 -> 1234_u128 -> 1234.0 -> 1234.0_felt
@@ -82,14 +66,14 @@ fn u128_to_bps_fp_felt(value: u128) -> felt252 {
 
 
 #[generate_trait]
-impl VaultFacadeImpl of VaultFacadeTrait {
+pub impl VaultFacadeImpl of VaultFacadeTrait {
     fn get_safe_dispatcher(ref self: VaultFacade) -> IVaultSafeDispatcher {
         IVaultSafeDispatcher { contract_address: self.contract_address() }
     }
 
     // Generate a JobRequest with custom timestamp and serialize it
     fn generate_custom_job_request_serialized(
-        ref self: VaultFacade, timestamp: u64
+        ref self: VaultFacade, timestamp: u64,
     ) -> Span<felt252> {
         let j = JobRequest {
             program_id: self.get_program_id(),
@@ -196,7 +180,7 @@ impl VaultFacadeImpl of VaultFacadeTrait {
     fn deposit_multiple(
         ref self: VaultFacade,
         mut amounts: Span<u256>,
-        mut liquidity_providers: Span<ContractAddress>
+        mut liquidity_providers: Span<ContractAddress>,
     ) -> Array<u256> {
         assert_two_arrays_equal_length(liquidity_providers, amounts);
         let mut updated_unlocked_positions = array![];
@@ -206,9 +190,9 @@ impl VaultFacadeImpl of VaultFacadeTrait {
                     let amount = amounts.pop_front().unwrap();
                     updated_unlocked_positions.append(self.deposit(*amount, *liquidity_provider));
                 },
-                Option::None => { break (); }
+                Option::None => { break (); },
             };
-        };
+        }
         updated_unlocked_positions
     }
 
@@ -245,7 +229,7 @@ impl VaultFacadeImpl of VaultFacadeTrait {
     fn withdraw_multiple(
         ref self: VaultFacade,
         mut amounts: Span<u256>,
-        mut liquidity_providers: Span<ContractAddress>
+        mut liquidity_providers: Span<ContractAddress>,
     ) -> Array<u256> {
         assert_two_arrays_equal_length(liquidity_providers, amounts);
         let mut unlocked_bals = array![];
@@ -255,16 +239,16 @@ impl VaultFacadeImpl of VaultFacadeTrait {
                     let amount = amounts.pop_front().unwrap();
                     unlocked_bals.append(self.withdraw(*amount, *liquidity_provider));
                 },
-                Option::None => { break (); }
+                Option::None => { break (); },
             };
-        };
+        }
         unlocked_bals
     }
 
     fn queue_multiple_withdrawals(
         ref self: VaultFacade,
         mut liquidity_providers: Span<ContractAddress>,
-        mut bps_multi: Span<u128>
+        mut bps_multi: Span<u128>,
     ) {
         loop {
             match liquidity_providers.pop_front() {
@@ -272,7 +256,7 @@ impl VaultFacadeImpl of VaultFacadeTrait {
                     let bps = bps_multi.pop_front().unwrap();
                     self.queue_withdrawal(*lp, *bps);
                 },
-                Option::None => { break (); }
+                Option::None => { break (); },
             };
         };
     }
@@ -281,7 +265,7 @@ impl VaultFacadeImpl of VaultFacadeTrait {
         let expected_stashed_amount = self.get_lp_stashed_balance(account);
         let actual_stashed_amount = self.vault_dispatcher.withdraw_stash(account);
         sanity_checks::claim_queued_liquidity(
-            ref self, expected_stashed_amount, actual_stashed_amount
+            ref self, expected_stashed_amount, actual_stashed_amount,
         )
     }
 
@@ -289,14 +273,14 @@ impl VaultFacadeImpl of VaultFacadeTrait {
     /// State transition
 
     fn fossil_callback(
-        ref self: VaultFacade, request: Span<felt252>, result: Span<felt252>
+        ref self: VaultFacade, request: Span<felt252>, result: Span<felt252>,
     ) -> u256 {
         set_contract_address(self.get_fossil_client_address());
         let payout = self.vault_dispatcher.fossil_callback(request, result);
 
         let mut current_round = self.get_current_round();
         eth_supply_and_approve_all_bidders(
-            current_round.contract_address(), self.get_eth_address()
+            current_round.contract_address(), self.get_eth_address(),
         );
 
         payout
@@ -304,7 +288,7 @@ impl VaultFacadeImpl of VaultFacadeTrait {
 
     #[feature("safe_dispatcher")]
     fn fossil_callback_expect_error(
-        ref self: VaultFacade, request: Span<felt252>, result: Span<felt252>, error: felt252
+        ref self: VaultFacade, request: Span<felt252>, result: Span<felt252>, error: felt252,
     ) {
         let safe_vault = self.get_safe_dispatcher();
         safe_vault.fossil_callback(request, result).expect_err(error);
@@ -347,7 +331,7 @@ impl VaultFacadeImpl of VaultFacadeTrait {
 
 
     fn settle_option_round(
-        ref self: VaultFacade, job_request: Span<felt252>, verifier_data: Span<felt252>
+        ref self: VaultFacade, job_request: Span<felt252>, verifier_data: Span<felt252>,
     ) -> u256 {
         // Settle the current round
 
@@ -367,7 +351,7 @@ impl VaultFacadeImpl of VaultFacadeTrait {
         ref self: VaultFacade,
         job_request: Span<felt252>,
         verifier_data: Span<felt252>,
-        error: felt252
+        error: felt252,
     ) {
         let safe_vault = self.get_safe_dispatcher();
         safe_vault.fossil_callback(job_request, verifier_data).expect_err(error);
@@ -375,7 +359,7 @@ impl VaultFacadeImpl of VaultFacadeTrait {
 
     /// Fossil
 
-    fn get_request_to_start_first_round_serialized(ref self: VaultFacade,) -> Span<felt252> {
+    fn get_request_to_start_first_round_serialized(ref self: VaultFacade) -> Span<felt252> {
         self.vault_dispatcher.get_request_to_start_first_round()
     }
 
@@ -388,7 +372,7 @@ impl VaultFacadeImpl of VaultFacadeTrait {
         Serde::deserialize(ref request).expect('failed to fetch request')
     }
 
-    fn get_request_to_start_first_round(ref self: VaultFacade,) -> JobRequest {
+    fn get_request_to_start_first_round(ref self: VaultFacade) -> JobRequest {
         let mut request = self.get_request_to_start_first_round_serialized();
         Serde::deserialize(ref request).expect('failed to fetch request')
     }
@@ -436,7 +420,7 @@ impl VaultFacadeImpl of VaultFacadeTrait {
     }
 
     fn get_lp_locked_balances(
-        ref self: VaultFacade, mut liquidity_providers: Span<ContractAddress>
+        ref self: VaultFacade, mut liquidity_providers: Span<ContractAddress>,
     ) -> Array<u256> {
         let mut balances = array![];
         loop {
@@ -445,9 +429,9 @@ impl VaultFacadeImpl of VaultFacadeTrait {
                     let balance = self.get_lp_locked_balance(*liquidity_provider);
                     balances.append(balance);
                 },
-                Option::None => { break (); }
+                Option::None => { break (); },
             };
-        };
+        }
         balances
     }
 
@@ -470,14 +454,14 @@ impl VaultFacadeImpl of VaultFacadeTrait {
                     let balance = self.get_lp_queued_bps(*liquidity_provider);
                     balances.append(balance);
                 },
-                Option::None => { break (); }
+                Option::None => { break (); },
             };
-        };
+        }
         balances
     }
 
     fn get_lp_stashed_balances(
-        ref self: VaultFacade, mut liquidity_providers: Span<ContractAddress>
+        ref self: VaultFacade, mut liquidity_providers: Span<ContractAddress>,
     ) -> Array<u256> {
         let mut balances = array![];
         loop {
@@ -486,9 +470,9 @@ impl VaultFacadeImpl of VaultFacadeTrait {
                     let balance = self.get_lp_stashed_balance(*liquidity_provider);
                     balances.append(balance);
                 },
-                Option::None => { break (); }
+                Option::None => { break (); },
             }
-        };
+        }
         balances
     }
 
@@ -497,7 +481,7 @@ impl VaultFacadeImpl of VaultFacadeTrait {
     }
 
     fn get_lp_unlocked_balances(
-        ref self: VaultFacade, mut liquidity_providers: Span<ContractAddress>
+        ref self: VaultFacade, mut liquidity_providers: Span<ContractAddress>,
     ) -> Array<u256> {
         let mut balances = array![];
         loop {
@@ -506,9 +490,9 @@ impl VaultFacadeImpl of VaultFacadeTrait {
                     let balance = self.get_lp_unlocked_balance(*liquidity_provider);
                     balances.append(balance);
                 },
-                Option::None => { break (); }
+                Option::None => { break (); },
             };
-        };
+        }
         balances
     }
 
@@ -517,7 +501,7 @@ impl VaultFacadeImpl of VaultFacadeTrait {
     }
 
     fn get_lp_locked_and_unlocked_balance(
-        ref self: VaultFacade, liquidity_provider: ContractAddress
+        ref self: VaultFacade, liquidity_provider: ContractAddress,
     ) -> (u256, u256) {
         let locked = self.vault_dispatcher.get_account_locked_balance(liquidity_provider);
         let unlocked = self.vault_dispatcher.get_account_unlocked_balance(liquidity_provider);
@@ -526,7 +510,7 @@ impl VaultFacadeImpl of VaultFacadeTrait {
 
     // @note replace this with get_lp_locked_and_unlocked_balances
     fn get_lp_locked_and_unlocked_balances(
-        ref self: VaultFacade, mut liquidity_providers: Span<ContractAddress>
+        ref self: VaultFacade, mut liquidity_providers: Span<ContractAddress>,
     ) -> Array<(u256, u256)> {
         let mut spreads = array![];
         loop {
@@ -536,14 +520,14 @@ impl VaultFacadeImpl of VaultFacadeTrait {
                         .get_lp_locked_and_unlocked_balance(*liquidity_provider);
                     spreads.append(locked_and_unlocked);
                 },
-                Option::None => { break (); }
+                Option::None => { break (); },
             };
-        };
+        }
         spreads
     }
 
     fn get_lp_locked_and_unlocked_and_stashed_balance(
-        ref self: VaultFacade, liquidity_provider: ContractAddress
+        ref self: VaultFacade, liquidity_provider: ContractAddress,
     ) -> (u256, u256, u256) {
         let locked = self.vault_dispatcher.get_account_locked_balance(liquidity_provider);
         let unlocked = self.vault_dispatcher.get_account_unlocked_balance(liquidity_provider);
@@ -552,7 +536,7 @@ impl VaultFacadeImpl of VaultFacadeTrait {
     }
 
     fn get_lp_locked_and_unlocked_and_stashed_balances(
-        ref self: VaultFacade, mut liquidity_providers: Span<ContractAddress>
+        ref self: VaultFacade, mut liquidity_providers: Span<ContractAddress>,
     ) -> Array<(u256, u256, u256)> {
         let mut spreads = array![];
         loop {
@@ -562,9 +546,9 @@ impl VaultFacadeImpl of VaultFacadeTrait {
                         .get_lp_locked_and_unlocked_and_stashed_balance(*liquidity_provider);
                     spreads.append(balances);
                 },
-                Option::None => { break (); }
+                Option::None => { break (); },
             };
-        };
+        }
         spreads
     }
 
@@ -600,7 +584,7 @@ impl VaultFacadeImpl of VaultFacadeTrait {
     }
 
     fn get_total_locked_and_unlocked_and_stashed_balance(
-        ref self: VaultFacade
+        ref self: VaultFacade,
     ) -> (u256, u256, u256) {
         let locked = self.vault_dispatcher.get_vault_locked_balance();
         let unlocked = self.vault_dispatcher.get_vault_unlocked_balance();
@@ -662,4 +646,3 @@ impl VaultFacadeImpl of VaultFacadeTrait {
         self.vault_dispatcher.get_proving_delay()
     }
 }
-

--- a/src/tests/utils/helpers/accelerators.cairo
+++ b/src/tests/utils/helpers/accelerators.cairo
@@ -1,52 +1,38 @@
-use starknet::{
-    contract_address_const, get_block_timestamp, ContractAddress,
-    testing::{set_block_timestamp, set_contract_address}
-};
-use core::fmt::Display;
 use pitch_lake::{
-    vault::contract::Vault::L1Data,
-    vault::interface::{JobRequest, IVaultDispatcher, IVaultDispatcherTrait},
-    option_round::{
-        contract::{OptionRound},
-        interface::{
-            PricingData, OptionRoundState, IOptionRoundDispatcher, IOptionRoundDispatcherTrait,
-        },
-    },
+    vault::interface::L1Data, vault::interface::{IVaultDispatcherTrait},
     tests::{
         utils::{
             lib::{
-                test_accounts::{
-                    vault_manager, liquidity_provider_1, option_bidder_buyer_1, bystander,
-                    option_bidders_get, liquidity_providers_get,
-                },
+                test_accounts::{bystander, liquidity_providers_get, option_bidders_get},
                 variables::{decimals},
             },
             helpers::{ // accelerators::{accelerate_to_auction_custom_auction_params},
-                event_helpers::{clear_event_logs,},
-                general_helpers::{to_gwei, assert_two_arrays_equal_length, get_erc20_balances},
+                general_helpers::{to_gwei},
                 //setup::{deploy_custom_option_round},
             },
             facades::{
-                option_round_facade::{OptionRoundFacade, OptionRoundFacadeTrait},
+                option_round_facade::{OptionRoundFacadeTrait},
                 vault_facade::{VaultFacade, VaultFacadeTrait},
             },
         },
     },
 };
+use starknet::testing::{set_block_timestamp, set_contract_address};
+use starknet::{ContractAddress, get_block_timestamp};
 
 
 /// Accelerators ///
 
 // Start the auction with LP1 depositing 100 eth
-fn accelerate_to_auctioning(ref self: VaultFacade) -> u256 {
+pub fn accelerate_to_auctioning(ref self: VaultFacade) -> u256 {
     accelerate_to_auctioning_custom(
-        ref self, array![*liquidity_providers_get(1)[0]].span(), array![100 * decimals()].span()
+        ref self, array![*liquidity_providers_get(1)[0]].span(), array![100 * decimals()].span(),
     )
 }
 
 // Start the auction with custom deposits
-fn accelerate_to_auctioning_custom(
-    ref self: VaultFacade, liquidity_providers: Span<ContractAddress>, amounts: Span<u256>
+pub fn accelerate_to_auctioning_custom(
+    ref self: VaultFacade, liquidity_providers: Span<ContractAddress>, amounts: Span<u256>,
 ) -> u256 {
     // Deposit liquidity
     self.deposit_multiple(amounts, liquidity_providers);
@@ -57,7 +43,7 @@ fn accelerate_to_auctioning_custom(
 /// Ending Auction
 
 // End the auction, OB1 bids for all options at reserve price
-fn accelerate_to_running(ref self: VaultFacade) -> (u256, u256) {
+pub fn accelerate_to_running(ref self: VaultFacade) -> (u256, u256) {
     let mut current_round = self.get_current_round();
     let bid_amount = current_round.get_total_options_available();
     let bid_price = current_round.get_reserve_price();
@@ -65,16 +51,16 @@ fn accelerate_to_running(ref self: VaultFacade) -> (u256, u256) {
         ref self,
         array![*option_bidders_get(1)[0]].span(),
         array![bid_amount].span(),
-        array![bid_price].span()
+        array![bid_price].span(),
     )
 }
 
 // End the auction with custom bids
-fn accelerate_to_running_custom(
+pub fn accelerate_to_running_custom(
     ref self: VaultFacade,
     bidders: Span<ContractAddress>,
     max_amounts: Span<u256>,
-    prices: Span<u256>
+    prices: Span<u256>,
 ) -> (u256, u256) {
     let mut current_round = self.get_current_round();
     current_round.place_bids(max_amounts, prices, bidders);
@@ -85,7 +71,7 @@ fn accelerate_to_running_custom(
 
 /// Settling option round
 
-fn accelerate_to_settled_custom(ref self: VaultFacade, l1_data: L1Data) -> u256 {
+pub fn accelerate_to_settled_custom(ref self: VaultFacade, l1_data: L1Data) -> u256 {
     // Get the data request to fulfill
     let mut j = array![];
     self.get_request_to_settle_round().serialize(ref j);
@@ -98,9 +84,9 @@ fn accelerate_to_settled_custom(ref self: VaultFacade, l1_data: L1Data) -> u256 
 }
 
 // Settle the option round with a custom settlement price (compared to strike to determine payout)
-fn accelerate_to_settled(ref self: VaultFacade, twap: u256) -> u256 {
+pub fn accelerate_to_settled(ref self: VaultFacade, twap: u256) -> u256 {
     accelerate_to_settled_custom(
-        ref self, L1Data { twap, max_return: 5000, reserve_price: to_gwei(2) }
+        ref self, L1Data { twap, max_return: 5000, reserve_price: to_gwei(2) },
     )
 }
 
@@ -110,32 +96,32 @@ fn accelerate_to_settled(ref self: VaultFacade, twap: u256) -> u256 {
 /// Timeskip and do nothing
 
 // Jump past the auction end date
-fn timeskip_past_auction_end_date(ref self: VaultFacade) {
+pub fn timeskip_past_auction_end_date(ref self: VaultFacade) {
     let mut current_round = self.get_current_round();
     set_block_timestamp(current_round.get_auction_end_date());
 }
 
 // Jump past the option expiry date
-fn timeskip_past_option_expiry_date(ref self: VaultFacade) {
+pub fn timeskip_past_option_expiry_date(ref self: VaultFacade) {
     let mut current_round = self.get_current_round();
     set_block_timestamp(current_round.get_option_settlement_date());
 }
 
 // Jump past the round transition period
-fn timeskip_past_round_transition_period(ref self: VaultFacade) {
+pub fn timeskip_past_round_transition_period(ref self: VaultFacade) {
     let now = get_block_timestamp();
     let round_transition_period = self.get_round_transition_period();
     set_block_timestamp(now + round_transition_period);
 }
 
 // Jump to settlement date includes proving delay
-fn timeskip_to_settlement_date(ref self: VaultFacade) {
+pub fn timeskip_to_settlement_date(ref self: VaultFacade) {
     let mut current_round = self.get_current_round();
     set_block_timestamp(current_round.get_option_settlement_date() + self.get_proving_delay());
 }
 
 // Jump to settlement date does not include proving delay
-fn timeskip_to_settlement_date_no_delay(ref self: VaultFacade) {
+pub fn timeskip_to_settlement_date_no_delay(ref self: VaultFacade) {
     let mut current_round = self.get_current_round();
     set_block_timestamp(current_round.get_option_settlement_date());
 }
@@ -143,17 +129,16 @@ fn timeskip_to_settlement_date_no_delay(ref self: VaultFacade) {
 /// Timeskip and do something
 
 // Jump past round transition period and start the auction
-fn timeskip_and_start_auction(ref self: VaultFacade) -> u256 {
+pub fn timeskip_and_start_auction(ref self: VaultFacade) -> u256 {
     timeskip_past_round_transition_period(ref self);
     set_contract_address(bystander());
     self.vault_dispatcher.start_auction()
 }
 
 // Jump to the auction end date and end the auction
-fn timeskip_and_end_auction(ref self: VaultFacade) -> (u256, u256) {
+pub fn timeskip_and_end_auction(ref self: VaultFacade) -> (u256, u256) {
     let mut current_round = self.get_current_round();
     set_block_timestamp(current_round.get_auction_end_date());
     set_contract_address(bystander());
     self.vault_dispatcher.end_auction()
 }
-

--- a/src/tests/utils/helpers/general_helpers.cairo
+++ b/src/tests/utils/helpers/general_helpers.cairo
@@ -1,123 +1,138 @@
-use openzeppelin_token::erc20::interface::{ERC20ABIDispatcher, ERC20ABIDispatcherTrait,};
-use starknet::{ContractAddress};
+use openzeppelin_token::erc20::interface::{ERC20ABIDispatcher, ERC20ABIDispatcherTrait};
+use starknet::ContractAddress;
 
 /// Array helpers ///
 
-fn to_gwei(value: u256) -> u256 {
+pub fn to_gwei(value: u256) -> u256 {
     value * 1_000_000_000
 }
 
 // Create array of length `len`, each element is `amount` (For bids use the function twice for price
 // and amount)
-fn create_array_linear<T, +Drop<T>, +Copy<T>>(amount: T, len: u32) -> Array<T> {
+pub fn create_array_linear<T, +Drop<T>, +Copy<T>>(amount: T, len: u32) -> Array<T> {
     let mut arr = array![];
     let mut index = 0;
     while (index < len) {
         arr.append(amount);
         index += 1;
-    };
+    }
     arr
 }
 
 // Create array of length `len`, each element is `amount + index * step` (For bids use the function
 // twice for price and amount)
-fn create_array_gradient(amount: u256, step: u256, len: u32) -> Array<u256> {
+pub fn create_array_gradient(amount: u256, step: u256, len: u32) -> Array<u256> {
     let mut arr: Array<u256> = array![];
     let mut index: u32 = 0;
     while (index < len) {
         arr.append(amount + index.into() * step);
         index += 1;
-    };
+    }
     arr
 }
 
 // Create array of length `len`, each element is `amount - index * step` (For bids use the function
 // twice for price and amount)
-fn create_array_gradient_reverse(amount: u256, step: u256, len: u32) -> Array<u256> {
+pub fn create_array_gradient_reverse(amount: u256, step: u256, len: u32) -> Array<u256> {
     let mut arr: Array<u256> = array![];
     let mut index: u32 = 0;
     while (index < len) {
         arr.append(amount - index.into() * step);
         index += 1;
-    };
+    }
     arr
 }
 
 // Sum all of the u256s in a given span
-fn sum_u256_array(mut arr: Span<u256>) -> u256 {
+pub fn sum_u256_array(mut arr: Span<u256>) -> u256 {
     let mut sum = 0;
-    loop {
-        match arr.pop_front() {
-            Option::Some(el) => { sum += *el; },
-            Option::None => { break; }
-        }
-    };
+    for el in arr {
+        sum += *el;
+    }
+    //  loop {
+    //      match arr.pop_front() {
+    //          Option::Some(el) => { sum += *el; },
+    //          Option::None => { break; },
+    //      }
+    //  }
     sum
 }
 
 // Sum the total amount paid for multiple bids.
-fn get_total_bids_amount(mut bid_prices: Span<u256>, mut bid_amounts: Span<u256>) -> u256 {
+pub fn get_total_bids_amount(mut bid_prices: Span<u256>, mut bid_amounts: Span<u256>) -> u256 {
     assert_two_arrays_equal_length(bid_prices, bid_amounts);
     let mut sum = 0;
-    loop {
-        match bid_prices.pop_front() {
-            Option::Some(bid_price) => {
-                let bid_amount = bid_amounts.pop_front().unwrap();
-                sum += *bid_amount * *bid_price;
-            },
-            Option::None => { break (); }
-        }
-    };
+    for i in 0..bid_prices.len() {
+        sum += *bid_prices[i] * *bid_amounts[i];
+    }
+    //    loop {
+    //        match bid_prices.pop_front() {
+    //            Option::Some(bid_price) => {
+    //                let bid_amount = bid_amounts.pop_front().unwrap();
+    //                sum += *bid_amount * *bid_price;
+    //            },
+    //            Option::None => { break (); },
+    //        }
+    //    }
     sum
 }
 
 // Assert two arrays of any type are equal
-fn assert_two_arrays_equal_length<T, V>(arr1: Span<T>, arr2: Span<V>) {
+pub fn assert_two_arrays_equal_length<T, V>(arr1: Span<T>, arr2: Span<V>) {
     assert(arr1.len() == arr2.len(), 'Arrays not equal length');
 }
 
 // Multiply each element in an array by a scalar
-fn scale_array<T, +Drop<T>, +Copy<T>, +Mul<T>>(mut arr: Span<T>, scalar: T) -> Array<T> {
+pub fn scale_array<T, +Drop<T>, +Copy<T>, +Mul<T>>(mut arr: Span<T>, scalar: T) -> Array<T> {
     let mut scaled: Array<T> = array![];
-    loop {
-        match arr.pop_front() {
-            Option::Some(el) => { scaled.append(*el * scalar); },
-            Option::None => { break (); }
-        }
-    };
+    for el in arr {
+        scaled.append(*el * scalar);
+    }
+    //loop {
+    //    match arr.pop_front() {
+    //        Option::Some(el) => { scaled.append(*el * scalar); },
+    //        Option::None => { break (); },
+    //    }
+    //}
     scaled
 }
 
 // Multiply each element in an array by the corresponding element in another array
-fn multiply_arrays<T, +Drop<T>, +Copy<T>, +Mul<T>>(
-    mut arr1: Span<T>, mut arr2: Span<T>
+pub fn multiply_arrays<T, +Drop<T>, +Copy<T>, +Mul<T>>(
+    mut arr1: Span<T>, mut arr2: Span<T>,
 ) -> Array<T> {
     assert_two_arrays_equal_length(arr1, arr2);
     let mut multiplied: Array<T> = array![];
-    loop {
-        match arr1.pop_front() {
-            Option::Some(el1) => {
-                let el2 = arr2.pop_front().unwrap();
-                multiplied.append(*el1 * *el2);
-            },
-            Option::None => { break (); }
-        }
-    };
+    for i in 0..arr1.len() {
+        multiplied.append(*arr1[i] * *arr2[i]);
+    }
+    // loop {
+    //     match arr1.pop_front() {
+    //         Option::Some(el1) => {
+    //             let el2 = arr2.pop_front().unwrap();
+    //             multiplied.append(*el1 * *el2);
+    //         },
+    //         Option::None => { break (); },
+    //     }
+    // }
     multiplied
 }
 // Make an array from a span
-fn span_to_array<T, +Drop<T>, +Copy<T>>(mut span: Span<T>) -> Array<T> {
+pub fn span_to_array<T, +Drop<T>, +Copy<T>>(mut span: Span<T>) -> Array<T> {
     let mut arr = array![];
-    loop {
-        match span.pop_front() {
-            Option::Some(el) => { arr.append(*el); },
-            Option::None => { break (); }
-        }
-    };
+    for el in span {
+        arr.append(*el);
+    }
+    //loop {
+    //    match span.pop_front() {
+    //        Option::Some(el) => { arr.append(*el); },
+    //        Option::None => { break (); },
+    //    }
+    //}
     arr
 }
 
-fn pow(base: u256, exp: u256,) -> u256 {
+pub fn pow(base: u256, exp: u256) -> u256 {
     if exp == 0 {
         1
     } else if exp == 1 {
@@ -129,19 +144,24 @@ fn pow(base: u256, exp: u256,) -> u256 {
     }
 }
 
-fn to_wei(value: u256, decimals: u8) -> u256 {
+pub fn to_wei(value: u256, decimals: u8) -> u256 {
     value * (pow(10, decimals.into()))
 }
 
-fn to_wei_multi(mut values: Span<u256>, mut decimals: u8) -> Span<u256> {
+pub fn to_wei_multi(mut values: Span<u256>, mut decimals: u8) -> Span<u256> {
     let mut arr_res = array![];
 
-    loop {
-        match values.pop_front() {
-            Option::Some(value) => { arr_res.append(to_wei(*value, decimals.into())); },
-            Option::None => { break; }
-        }
-    };
+    for value in values {
+        arr_res.append(to_wei(*value, decimals.into()));
+    }
+
+    //    loop {
+    //        match values.pop_front() {
+    //            Option::Some(value) => { arr_res.append(to_wei(*value, decimals.into())); },
+    //            Option::None => { break; },
+    //        }
+    //}
+
     arr_res.span()
 }
 
@@ -149,44 +169,53 @@ fn to_wei_multi(mut values: Span<u256>, mut decimals: u8) -> Span<u256> {
 /// ERC20 Helpers ///
 
 // Get erc20 balances for an address
-fn get_erc20_balance(contract_address: ContractAddress, account_address: ContractAddress) -> u256 {
+pub fn get_erc20_balance(
+    contract_address: ContractAddress, account_address: ContractAddress,
+) -> u256 {
     let contract = ERC20ABIDispatcher { contract_address };
     contract.balance_of(account_address)
 }
 
 // Get erc20 balances for multiple addresses
-fn get_erc20_balances(
-    contract_address: ContractAddress, mut account_addresses: Span<ContractAddress>
+pub fn get_erc20_balances(
+    contract_address: ContractAddress, mut account_addresses: Span<ContractAddress>,
 ) -> Array<u256> {
     let mut balances = array![];
-    loop {
-        match account_addresses.pop_front() {
-            Option::Some(addr) => { balances.append(get_erc20_balance(contract_address, *addr)); },
-            Option::None => { break (); }
-        }
-    };
+    for addr in account_addresses {
+        balances.append(get_erc20_balance(contract_address, *addr));
+    }
+    //    loop {
+    //        match account_addresses.pop_front() {
+    //            Option::Some(addr) => { balances.append(get_erc20_balance(contract_address,
+    //            *addr)); }, Option::None => { break (); },
+    //        }
+    //    }
     balances
 }
 
 // Return each elements portion of the 'amount' corresponding to the total of the array
 // @dev Scaling with bps for precision
 // @dev Used to determine how many premiums and payouts belong to an account
-fn get_portion_of_amount(mut arr: Span<u256>, amount: u256) -> Array<u256> {
+pub fn get_portion_of_amount(mut arr: Span<u256>, amount: u256) -> Array<u256> {
     let total = sum_u256_array(arr);
     let mut portions = array![];
-    loop {
-        match arr.pop_front() {
-            Option::Some(value) => {
-                let portion = (*value * amount) / total;
-                portions.append(portion);
-            },
-            Option::None => { break (); }
-        }
-    };
+    for value in arr {
+        let portion = (*value * amount) / total;
+        portions.append(portion);
+    }
+    //loop {
+    //    match arr.pop_front() {
+    //        Option::Some(value) => {
+    //            let portion = (*value * amount) / total;
+    //            portions.append(portion);
+    //        },
+    //        Option::None => { break (); },
+    //    }
+    //}
     portions
 }
 
-fn assert_u256s_equal_in_range(value1: u256, value2: u256, range: u256) {
+pub fn assert_u256s_equal_in_range(value1: u256, value2: u256, range: u256) {
     let lower_bound = if range > value2 {
         0
     } else {

--- a/src/tests/utils/lib/test_accounts.cairo
+++ b/src/tests/utils/lib/test_accounts.cairo
@@ -1,20 +1,21 @@
-use starknet::{ContractAddress, contract_address_const};
+use starknet::ContractAddress;
 
-fn vault_manager() -> ContractAddress {
-    contract_address_const::<'vault_manager'>()
+pub fn vault_manager() -> ContractAddress {
+    'vault_manager'.try_into().unwrap()
 }
 
-fn weth_owner() -> ContractAddress {
-    contract_address_const::<'weth_owner'>()
+pub fn weth_owner() -> ContractAddress {
+    'weth_owner'.try_into().unwrap()
 }
 
 // Bystander, perform state transition functions on vault so all gas costs are on it
-fn bystander() -> ContractAddress {
-    contract_address_const::<'bystander'>()
+pub fn bystander() -> ContractAddress {
+    'bystander'.try_into().unwrap()
 }
 
+
 // Get an array of liquiditiy providers
-fn liquidity_providers_get(number: u32) -> Array<ContractAddress> {
+pub fn liquidity_providers_get(number: u32) -> Array<ContractAddress> {
     let mut data: Array<ContractAddress> = array![];
     let mut index = 0;
     while index < number {
@@ -25,17 +26,17 @@ fn liquidity_providers_get(number: u32) -> Array<ContractAddress> {
             3 => liquidity_provider_4(),
             4 => liquidity_provider_5(),
             5 => liquidity_provider_6(),
-            _ => contract_address_const::<'liquidity_provider_1'>(),
+            _ => liquidity_provider_1(),
         };
 
         data.append(contractAddress);
         index = index + 1;
-    };
+    }
     data
 }
 
 // Get an array of option bidders/buyers
-fn option_bidders_get(number: u32) -> Array<ContractAddress> {
+pub fn option_bidders_get(number: u32) -> Array<ContractAddress> {
     let mut data: Array<ContractAddress> = array![];
     let mut index = 0;
     while index < number {
@@ -46,52 +47,54 @@ fn option_bidders_get(number: u32) -> Array<ContractAddress> {
             3 => option_bidder_buyer_4(),
             4 => option_bidder_buyer_5(),
             5 => option_bidder_buyer_6(),
-            _ => contract_address_const::<'option_bidder_buyer_1'>(),
+            _ => option_bidder_buyer_1(),
         };
 
         data.append(contractAddress);
         index = index + 1;
-    };
+    }
     data
 }
 
 // Individual liquidity providers and option bidders/buyers
-fn liquidity_provider_1() -> ContractAddress {
-    contract_address_const::<'liquidity_provider_1'>()
+pub fn liquidity_provider_1() -> ContractAddress {
+    'liquidity_provider_1'.try_into().unwrap()
 }
-fn liquidity_provider_2() -> ContractAddress {
-    contract_address_const::<'liquidity_provider_2'>()
-}
-fn liquidity_provider_3() -> ContractAddress {
-    contract_address_const::<'liquidity_provider_3'>()
-}
-fn liquidity_provider_4() -> ContractAddress {
-    contract_address_const::<'liquidity_provider_4'>()
-}
-fn liquidity_provider_5() -> ContractAddress {
-    contract_address_const::<'liquidity_provider_5'>()
-}
-fn liquidity_provider_6() -> ContractAddress {
-    contract_address_const::<'liquidity_provider_6'>()
-}
-fn option_bidder_buyer_1() -> ContractAddress {
-    contract_address_const::<'option_bidder_buyer1'>()
-}
-fn option_bidder_buyer_2() -> ContractAddress {
-    contract_address_const::<'option_bidder_buyer2'>()
-}
-fn option_bidder_buyer_3() -> ContractAddress {
-    contract_address_const::<'option_bidder_buyer3'>()
-}
-fn option_bidder_buyer_4() -> ContractAddress {
-    contract_address_const::<'option_bidder_buyer4'>()
-}
-fn option_bidder_buyer_5() -> ContractAddress {
-    contract_address_const::<'option_bidder_buyer5'>()
-}
-fn option_bidder_buyer_6() -> ContractAddress {
-    contract_address_const::<'option_bidder_buyer6'>()
-}
-// Owners/Admins for contracts
 
+pub fn liquidity_provider_2() -> ContractAddress {
+    'liquidity_provider_2'.try_into().unwrap()
+}
+
+pub fn liquidity_provider_3() -> ContractAddress {
+    'liquidity_provider_3'.try_into().unwrap()
+}
+
+pub fn liquidity_provider_4() -> ContractAddress {
+    'liquidity_provider_4'.try_into().unwrap()
+}
+pub fn liquidity_provider_5() -> ContractAddress {
+    'liquidity_provider_5'.try_into().unwrap()
+}
+pub fn liquidity_provider_6() -> ContractAddress {
+    'liquidity_provider_6'.try_into().unwrap()
+}
+pub fn option_bidder_buyer_1() -> ContractAddress {
+    'option_bidder_buyer1'.try_into().unwrap()
+}
+
+pub fn option_bidder_buyer_2() -> ContractAddress {
+    'option_bidder_buyer2'.try_into().unwrap()
+}
+pub fn option_bidder_buyer_3() -> ContractAddress {
+    'option_bidder_buyer3'.try_into().unwrap()
+}
+pub fn option_bidder_buyer_4() -> ContractAddress {
+    'option_bidder_buyer4'.try_into().unwrap()
+}
+pub fn option_bidder_buyer_5() -> ContractAddress {
+    'option_bidder_buyer5'.try_into().unwrap()
+}
+pub fn option_bidder_buyer_6() -> ContractAddress {
+    'option_bidder_buyer6'.try_into().unwrap()
+}
 

--- a/src/tests/utils/lib/variables.cairo
+++ b/src/tests/utils/lib/variables.cairo
@@ -1,34 +1,34 @@
-use starknet::{ContractAddress, contract_address_const};
+use starknet::ContractAddress;
 
-fn decimals() -> u256 {
+pub fn decimals() -> u256 {
     //10  ** 18
     1000000000000000000
 }
 
-fn minute_duration() -> u64 {
+pub fn minute_duration() -> u64 {
     60
 }
 
-fn hour_duration() -> u64 {
+pub fn hour_duration() -> u64 {
     60 * minute_duration()
 }
 
-fn day_duration() -> u64 {
+pub fn day_duration() -> u64 {
     24 * hour_duration()
 }
 
-fn week_duration() -> u64 {
+pub fn week_duration() -> u64 {
     7 * day_duration()
 }
 
-fn month_duration() -> u64 {
+pub fn month_duration() -> u64 {
     30 * day_duration()
 }
 
-fn zero_address() -> ContractAddress {
-    contract_address_const::<0>()
+pub fn zero_address() -> ContractAddress {
+    0.try_into().unwrap()
 }
 
-fn bps() -> u256 {
+pub fn bps() -> u256 {
     10000
 }

--- a/src/tests/vault/liquidity_providers/withdraw_tests.cairo
+++ b/src/tests/vault/liquidity_providers/withdraw_tests.cairo
@@ -1,45 +1,18 @@
-use core::option::OptionTrait;
 use core::array::SpanTrait;
-use openzeppelin_token::erc20::interface::{ERC20ABIDispatcherTrait,};
-use starknet::{
-    ClassHash, ContractAddress, contract_address_const, deploy_syscall,
-    Felt252TryIntoContractAddress, get_contract_address, get_block_timestamp,
-    testing::{set_block_timestamp, set_contract_address}
+use openzeppelin_token::erc20::interface::ERC20ABIDispatcherTrait;
+use pitch_lake::tests::utils::facades::option_round_facade::OptionRoundFacadeTrait;
+use pitch_lake::tests::utils::facades::vault_facade::VaultFacadeTrait;
+use pitch_lake::tests::utils::helpers::accelerators::{
+    accelerate_to_auctioning, accelerate_to_running, accelerate_to_settled,
 };
-use pitch_lake::{
-    library::eth::Eth, vault::{contract::Vault}, vault::contract::Vault::Errors,
-    tests::{
-        utils::{
-            helpers::{
-                general_helpers::{get_erc20_balances, sum_u256_array},
-                event_helpers::{
-                    pop_log, assert_no_events_left, assert_event_transfer,
-                    assert_event_vault_withdrawal, clear_event_logs,
-                },
-                accelerators::{
-                    accelerate_to_auctioning, accelerate_to_auctioning_custom,
-                    accelerate_to_running, accelerate_to_settled, timeskip_and_start_auction,
-                },
-                setup::{setup_facade},
-            },
-            lib::{
-                test_accounts::{
-                    liquidity_provider_1, liquidity_provider_2, option_bidder_buyer_1,
-                    option_bidder_buyer_2, option_bidder_buyer_3, option_bidder_buyer_4,
-                    liquidity_providers_get,
-                },
-                variables::{decimals},
-            },
-            facades::{
-                option_round_facade::{OptionRoundFacade, OptionRoundFacadeTrait},
-                vault_facade::{VaultFacade, VaultFacadeTrait},
-            }
-        },
-    },
+use pitch_lake::tests::utils::helpers::event_helpers::{
+    assert_event_vault_withdrawal, clear_event_logs,
 };
-use debug::PrintTrait;
-
-
+use pitch_lake::tests::utils::helpers::general_helpers::{get_erc20_balances, sum_u256_array};
+use pitch_lake::tests::utils::helpers::setup::setup_facade;
+use pitch_lake::tests::utils::lib::test_accounts::{liquidity_provider_1, liquidity_providers_get};
+use pitch_lake::tests::utils::lib::variables::decimals;
+use pitch_lake::vault::contract::Vault::Errors;
 /// Failures ///
 
 // @note instead of testing withdrawing 0 fails or returns 0, we should just include in
@@ -62,7 +35,7 @@ fn test_withdrawing_more_than_unlocked_balance_fails() {
     let unlocked_balance = vault.get_lp_unlocked_balance(liquidity_provider);
     vault
         .withdraw_expect_error(
-            unlocked_balance + 1, liquidity_provider, Errors::InsufficientBalance
+            unlocked_balance + 1, liquidity_provider, Errors::InsufficientBalance,
         );
 }
 
@@ -89,23 +62,36 @@ fn test_withdrawal_events() {
         .withdraw_multiple(deposit_amounts, liquidity_providers);
 
     // Check event emissions
-    loop {
-        match liquidity_providers.pop_front() {
-            Option::Some(liquidity_provider) => {
-                let withdraw_amount = *deposit_amounts.pop_front().unwrap();
-                let unlocked_amount_after = lp_unlocked_balances_after.pop_front().unwrap();
-                vault_unlocked_balance_before -= withdraw_amount;
-                assert_event_vault_withdrawal(
-                    vault.contract_address(),
-                    *liquidity_provider,
-                    withdraw_amount,
-                    unlocked_amount_after, // account unlocked balance before the withdraw
-                    vault_unlocked_balance_before, // vault unlocked balance after the withdraw
-                );
-            },
-            Option::None => { break (); }
-        }
+    for i in 0..liquidity_providers.len() {
+        let lp = *liquidity_providers[i];
+        let withdraw_amount = *deposit_amounts[i];
+        let unlocked_amount_after = *lp_unlocked_balances_after[i];
+        vault_unlocked_balance_before -= withdraw_amount;
+        assert_event_vault_withdrawal(
+            vault.contract_address(),
+            lp,
+            withdraw_amount,
+            unlocked_amount_after, // account unlocked balance before the withdraw
+            vault_unlocked_balance_before // vault unlocked balance after the withdraw
+        );
     }
+    //loop {
+//    match liquidity_providers.pop_front() {
+//        Option::Some(liquidity_provider) => {
+//            let withdraw_amount = *deposit_amounts.pop_front().unwrap();
+//            let unlocked_amount_after = lp_unlocked_balances_after.pop_front().unwrap();
+//            vault_unlocked_balance_before -= withdraw_amount;
+//            assert_event_vault_withdrawal(
+//                vault.contract_address(),
+//                *liquidity_provider,
+//                withdraw_amount,
+//                unlocked_amount_after, // account unlocked balance before the withdraw
+//                vault_unlocked_balance_before // vault unlocked balance after the withdraw
+//            );
+//        },
+//        Option::None => { break (); },
+//    }
+//}
 }
 
 /// State Tests ///
@@ -136,21 +122,29 @@ fn test_withdrawing_from_vault_eth_transfer() {
     assert_eq!(vault_balance_after, vault_balance_before - total_withdrawals);
 
     // Check liquidity provider eth balances
-    loop {
-        match liquidity_providers.pop_front() {
-            Option::Some(_) => {
-                let lp_balance_before = lp_balances_before.pop_front().unwrap();
-                let lp_balance_after = lp_balances_after.pop_front().unwrap();
-                let withdraw_amount = *deposit_amounts.pop_front().unwrap();
+    for i in 0..liquidity_providers.len() {
+        let lp_balance_before = *lp_balances_before[i];
+        let lp_balance_after = *lp_balances_after[i];
+        let withdraw_amount = *deposit_amounts[i];
 
-                // Check eth transfers to liquidity provider
-                assert(
-                    lp_balance_after == lp_balance_before + withdraw_amount, 'lp eth balance wrong'
-                );
-            },
-            Option::None => { break (); }
-        }
+        assert(lp_balance_after == lp_balance_before + withdraw_amount, 'lp eth balance wrong');
     }
+    //    loop {
+//        match liquidity_providers.pop_front() {
+//            Option::Some(_) => {
+//                let lp_balance_before = lp_balances_before.pop_front().unwrap();
+//                let lp_balance_after = lp_balances_after.pop_front().unwrap();
+//                let withdraw_amount = *deposit_amounts.pop_front().unwrap();
+//
+//                // Check eth transfers to liquidity provider
+//                assert(
+//                    lp_balance_after == lp_balance_before + withdraw_amount, 'lp eth balance
+//                    wrong',
+//                );
+//            },
+//            Option::None => { break (); },
+//        }
+//    }
 }
 
 // Test withdrawal always come from the vault's unlocked pool, regardless of the state of the
@@ -161,7 +155,7 @@ fn test_withdrawing_always_come_from_unlocked_pool() {
     let (mut vault, _) = setup_facade();
     let mut current_round = vault.get_current_round();
     let deposit_amount = 100 * decimals();
-    let withdraw_amount = 1 * decimals();
+    let withdraw_amount = decimals();
     let liquidity_provider = liquidity_provider_1();
 
     // Withdraw while current round is auctioning
@@ -170,7 +164,8 @@ fn test_withdrawing_always_come_from_unlocked_pool() {
     let unlocked_amount_after = vault.withdraw(withdraw_amount, liquidity_provider);
 
     assert(
-        unlocked_amount_after == unlocked_amount_before - withdraw_amount, 'unlocked amount 1 wrong'
+        unlocked_amount_after == unlocked_amount_before - withdraw_amount,
+        'unlocked amount 1 wrong',
     );
 
     // Withdraw while current round is running
@@ -178,7 +173,8 @@ fn test_withdrawing_always_come_from_unlocked_pool() {
     let unlocked_amount_before = vault.get_lp_unlocked_balance(liquidity_provider);
     let unlocked_amount_after = vault.withdraw(withdraw_amount, liquidity_provider);
     assert(
-        unlocked_amount_after == unlocked_amount_before - withdraw_amount, 'unlocked amount 2 wrong'
+        unlocked_amount_after == unlocked_amount_before - withdraw_amount,
+        'unlocked amount 2 wrong',
     );
 
     // Withdraw while the current round is settled
@@ -186,6 +182,7 @@ fn test_withdrawing_always_come_from_unlocked_pool() {
     let unlocked_amount_before = vault.get_lp_unlocked_balance(liquidity_provider);
     let unlocked_amount_after = vault.withdraw(withdraw_amount, liquidity_provider);
     assert(
-        unlocked_amount_after == unlocked_amount_before - withdraw_amount, 'unlocked amount 3 wrong'
+        unlocked_amount_after == unlocked_amount_before - withdraw_amount,
+        'unlocked amount 3 wrong',
     );
 }

--- a/src/tests/vault/state_transition/option_settle_tests.cairo
+++ b/src/tests/vault/state_transition/option_settle_tests.cairo
@@ -1,57 +1,25 @@
-use starknet::{
-    ClassHash, ContractAddress, contract_address_const, deploy_syscall,
-    Felt252TryIntoContractAddress, get_contract_address, get_block_timestamp,
-    testing::{set_block_timestamp, set_contract_address}, contract_address::ContractAddressZeroable,
-};
-use openzeppelin_utils::serde::SerializedAppend;
 use openzeppelin_token::erc20::interface::ERC20ABIDispatcherTrait;
-use pitch_lake::{
-    library::{eth::Eth}, vault::interface::JobRequest,
-    vault::{
-        interface::{
-            L1Data, IVaultDispatcher, IVaultSafeDispatcher, IVaultDispatcherTrait,
-            IVaultSafeDispatcherTrait,
-        }
-    },
-    option_round::contract::OptionRound::Errors, option_round::interface::PricingData,
-    vault::interface::VerifierData,
-    tests::{
-        utils::{
-            helpers::{
-                general_helpers::{
-                    get_portion_of_amount, create_array_linear, create_array_gradient,
-                    get_erc20_balances, sum_u256_array, to_gwei,
-                },
-                event_helpers::{
-                    clear_event_logs, assert_event_option_settle, assert_event_transfer,
-                    assert_no_events_left, pop_log, assert_event_option_round_deployed_single,
-                    assert_event_option_round_deployed,
-                },
-                accelerators::{
-                    accelerate_to_auctioning, accelerate_to_running, accelerate_to_settled,
-                    accelerate_to_auctioning_custom, accelerate_to_running_custom
-                },
-                setup::{
-                    deploy_vault_with_events, setup_facade, setup_test_auctioning_providers,
-                    setup_test_running, AUCTION_DURATION, ROUND_TRANSITION_DURATION, ROUND_DURATION
-                },
-            },
-            lib::{
-                test_accounts::{
-                    liquidity_provider_1, liquidity_provider_2, option_bidder_buyer_1,
-                    option_bidder_buyer_2, option_bidder_buyer_3, option_bidder_buyer_4,
-                    liquidity_providers_get, liquidity_provider_3, liquidity_provider_4,
-                },
-                variables::{decimals},
-            },
-            facades::{
-                vault_facade::{VaultFacade, VaultFacadeTrait},
-                option_round_facade::{OptionRoundState, OptionRoundFacade, OptionRoundFacadeTrait},
-            },
-        },
-    }
+use pitch_lake::option_round::contract::OptionRound::Errors;
+use pitch_lake::option_round::interface::{OptionRoundState, PricingData};
+use pitch_lake::tests::utils::facades::option_round_facade::OptionRoundFacadeTrait;
+use pitch_lake::tests::utils::facades::vault_facade::{VaultFacade, VaultFacadeTrait};
+use pitch_lake::tests::utils::helpers::accelerators::{
+    accelerate_to_auctioning, accelerate_to_auctioning_custom, accelerate_to_running,
+    accelerate_to_running_custom, accelerate_to_settled,
 };
-use debug::PrintTrait;
+use pitch_lake::tests::utils::helpers::event_helpers::{
+    assert_event_option_round_deployed_single, assert_event_option_settle, clear_event_logs,
+};
+use pitch_lake::tests::utils::helpers::general_helpers::{create_array_gradient, to_gwei};
+use pitch_lake::tests::utils::helpers::setup::{
+    AUCTION_DURATION, ROUND_DURATION, ROUND_TRANSITION_DURATION, deploy_vault_with_events,
+    setup_facade, setup_test_auctioning_providers, setup_test_running,
+};
+use pitch_lake::tests::utils::lib::test_accounts::{liquidity_provider_1, option_bidder_buyer_1};
+use pitch_lake::tests::utils::lib::variables::decimals;
+use pitch_lake::vault::interface::{JobRequest, L1Data};
+use starknet::get_block_timestamp;
+use starknet::testing::set_block_timestamp;
 
 
 /// Failures ///
@@ -66,7 +34,7 @@ fn test_settling_option_round_while_round_auctioning_fails() {
     let req = vault_facade.get_request_to_settle_round_serialized();
     let res = vault_facade.generate_custom_job_result_from_l1_data_serialized(l1_data);
 
-    accelerate_to_auctioning(ref vault_facade,);
+    accelerate_to_auctioning(ref vault_facade);
 
     // Settle option round before auction ends
     vault_facade.settle_option_round_expect_error(req, res, Errors::OptionSettlementDateNotReached);
@@ -145,7 +113,7 @@ fn test_option_round_settled_event() {
 #[available_gas(500000000)]
 fn test_first_round_deployed_event() {
     set_block_timestamp(123);
-    let vault_dispatcher = deploy_vault_with_events(2222, 9999, contract_address_const::<'eth'>());
+    let vault_dispatcher = deploy_vault_with_events(2222, 9999, 'eth'.try_into().unwrap());
     let mut vault = VaultFacade { vault_dispatcher };
     let mut current_round = vault.get_current_round();
 
@@ -161,7 +129,7 @@ fn test_first_round_deployed_event() {
         exp_auction_start_date,
         exp_auction_end_date,
         exp_option_settlement_date,
-        pricing_data: PricingData { strike_price: 0, cap_level: 0, reserve_price: 0 }
+        pricing_data: PricingData { strike_price: 0, cap_level: 0, reserve_price: 0 },
     );
 
     assert_eq!(current_round.get_deployment_date(), exp_deployment_date);
@@ -177,40 +145,39 @@ fn test_first_round_deployed_event() {
 fn test_next_round_deployed_events() {
     let (mut vault, _) = setup_facade();
 
-    for i in 1_u64
-        ..4 {
-            let mut round_i = vault.get_current_round();
-            accelerate_to_auctioning(ref vault);
-            accelerate_to_running(ref vault);
-            clear_event_logs(array![vault.contract_address()]);
-            accelerate_to_settled(ref vault, round_i.get_strike_price());
+    for i in 1_u64..4 {
+        let mut round_i = vault.get_current_round();
+        accelerate_to_auctioning(ref vault);
+        accelerate_to_running(ref vault);
+        clear_event_logs(array![vault.contract_address()]);
+        accelerate_to_settled(ref vault, round_i.get_strike_price());
 
-            let mut round_i_plus_1 = vault.get_current_round();
-            let auction_start_date = round_i_plus_1.get_auction_start_date();
-            let auction_end_date = round_i_plus_1.get_auction_end_date();
-            let settlement_date = round_i_plus_1.get_option_settlement_date();
+        let mut round_i_plus_1 = vault.get_current_round();
+        let auction_start_date = round_i_plus_1.get_auction_start_date();
+        let auction_end_date = round_i_plus_1.get_auction_end_date();
+        let settlement_date = round_i_plus_1.get_option_settlement_date();
 
-            // Check new round is deployed
-            assert(i + 1 == round_i_plus_1.get_round_id(), 'round contract address wrong');
+        // Check new round is deployed
+        assert(i + 1 == round_i_plus_1.get_round_id(), 'round contract address wrong');
 
-            // Check the event emits correctly
-            let pricing_data = PricingData {
-                strike_price: round_i_plus_1.get_strike_price(),
-                cap_level: round_i_plus_1.get_cap_level(),
-                reserve_price: round_i_plus_1.get_reserve_price()
-            };
+        // Check the event emits correctly
+        let pricing_data = PricingData {
+            strike_price: round_i_plus_1.get_strike_price(),
+            cap_level: round_i_plus_1.get_cap_level(),
+            reserve_price: round_i_plus_1.get_reserve_price(),
+        };
 
-            assert(pricing_data != Default::default(), 'Pricing data not set correctly');
-            assert_event_option_round_deployed_single(
-                vault.contract_address(),
-                i + 1,
-                round_i_plus_1.contract_address(),
-                auction_start_date,
-                auction_end_date,
-                settlement_date,
-                pricing_data
-            );
-        }
+        assert(pricing_data != Default::default(), 'Pricing data not set correctly');
+        assert_event_option_round_deployed_single(
+            vault.contract_address(),
+            i + 1,
+            round_i_plus_1.contract_address(),
+            auction_start_date,
+            auction_end_date,
+            settlement_date,
+            pricing_data,
+        );
+    }
 }
 
 
@@ -254,14 +221,14 @@ fn test_settle_option_round_updates_round_state() {
         let mut current_round = vault.get_current_round();
 
         assert(
-            current_round.get_state() == OptionRoundState::Running, 'current round shd be running'
+            current_round.get_state() == OptionRoundState::Running, 'current round shd be running',
         );
 
         //accelerate_to_settled(ref vault, 0);
         accelerate_to_settled(ref vault, current_round.get_strike_price());
 
         assert(
-            current_round.get_state() == OptionRoundState::Settled, 'current round shd be settled'
+            current_round.get_state() == OptionRoundState::Settled, 'current round shd be settled',
         );
 
         rounds_to_run -= 1;
@@ -308,12 +275,12 @@ fn test_settling_option_round_transfers_payout() {
 fn test_settling_option_round_updates_locked_and_unlocked_balances() {
     let number_of_liquidity_providers = 4;
     let mut deposit_amounts = create_array_gradient(
-        100 * decimals(), 100 * decimals(), number_of_liquidity_providers
+        100 * decimals(), 100 * decimals(), number_of_liquidity_providers,
     )
         .span();
     //    let total_deposits = sum_u256_array(deposit_amounts);
     let (mut vault, _, liquidity_providers, _) = setup_test_auctioning_providers(
-        number_of_liquidity_providers, deposit_amounts
+        number_of_liquidity_providers, deposit_amounts,
     );
     let mut current_round = vault.get_current_round();
 
@@ -353,11 +320,11 @@ fn test_settling_option_round_updates_locked_and_unlocked_balances() {
     assert(total_premiums > 0, 'premiums shd be > 0');
     assert(
         (vault_locked_before, vault_unlocked_before) == (sold_liq, gained_liq),
-        'vault balance before wrong'
+        'vault balance before wrong',
     );
     assert(
         (vault_locked_after, vault_unlocked_after) == (0, gained_liq + remaining_liq),
-        'vault balance after wrong'
+        'vault balance after wrong',
     );
 
     // Check liquidity provider balances
@@ -384,18 +351,18 @@ fn test_settling_option_round_updates_locked_and_unlocked_balances() {
 
                 assert(
                     (
-                        lp_locked_balance_before, lp_unlocked_balance_before
+                        lp_locked_balance_before, lp_unlocked_balance_before,
                     ) == (lp_sold_liq, lp_gained_liq),
-                    'LP balance before wrong'
+                    'LP balance before wrong',
                 );
                 assert(
                     (
-                        lp_locked_balance_after, lp_unlocked_balance_after
+                        lp_locked_balance_after, lp_unlocked_balance_after,
                     ) == (0, lp_gained_liq + lp_remaining_liq),
-                    'LP balance after wrong'
+                    'LP balance after wrong',
                 );
             },
-            Option::None => { break (); }
+            Option::None => { break; },
         }
     };
 }
@@ -409,7 +376,7 @@ fn test_null_round_settling() {
     let liquidity_provider = liquidity_provider_1();
     let deposit_amount = 0;
     accelerate_to_auctioning_custom(
-        ref vault, array![liquidity_provider].span(), array![deposit_amount].span()
+        ref vault, array![liquidity_provider].span(), array![deposit_amount].span(),
     );
 
     let option_buyer = option_bidder_buyer_1();
@@ -417,7 +384,7 @@ fn test_null_round_settling() {
     let reserve_price = current_round.get_reserve_price();
     current_round
         .place_bid_expect_error(
-            options_available, reserve_price, option_buyer, Errors::NoOptionsToBidFor
+            options_available, reserve_price, option_buyer, Errors::NoOptionsToBidFor,
         );
 
     accelerate_to_running_custom(ref vault, array![].span(), array![].span(), array![].span());

--- a/src/types.cairo
+++ b/src/types.cairo
@@ -1,22 +1,18 @@
-use starknet::{ContractAddress, Event};
-use core::fmt::{Formatter, Error, Display};
+use starknet::ContractAddress;
 
 /// Errors
 pub mod Errors {
     pub const BidsShouldNotHaveSameTreeNonce: felt252 = 'Tree nonces should be unique';
 }
 
-pub mod Consts {}
-
-
 // The struct for a bid placed in a round's auction
 #[derive(Copy, Drop, Serde, starknet::Store, PartialEq)]
 pub struct Bid {
-    bid_id: felt252,
-    owner: ContractAddress,
-    amount: u256,
-    price: u256,
-    tree_nonce: u64,
+    pub bid_id: felt252,
+    pub owner: ContractAddress,
+    pub amount: u256,
+    pub price: u256,
+    pub tree_nonce: u64,
 }
 
 // Allows Bids to be sorted using >, >=, <, <=

--- a/src/vault/interface.cairo
+++ b/src/vault/interface.cairo
@@ -1,24 +1,23 @@
-use starknet::{ContractAddress, ClassHash};
-use pitch_lake::option_round::interface::OptionRoundState;
+use starknet::{ClassHash, ContractAddress};
 
 // @dev Constructor arguments
 #[derive(Drop, Serde)]
-struct ConstructorArgs {
-    verifier_address: ContractAddress,
-    eth_address: ContractAddress,
-    option_round_class_hash: ClassHash,
-    alpha: u128,
-    strike_level: i128,
-    round_transition_duration: u64,
-    auction_duration: u64,
-    round_duration: u64,
-    program_id: felt252,
-    proving_delay: u64,
+pub struct ConstructorArgs {
+    pub verifier_address: ContractAddress,
+    pub eth_address: ContractAddress,
+    pub option_round_class_hash: ClassHash,
+    pub alpha: u128,
+    pub strike_level: i128,
+    pub round_transition_duration: u64,
+    pub auction_duration: u64,
+    pub round_duration: u64,
+    pub program_id: felt252,
+    pub proving_delay: u64,
 }
 
 // The interface for the vault contract
 #[starknet::interface]
-trait IVault<TContractState> {
+pub trait IVault<TContractState> {
     /// Reads ///
 
     // @dev Get the alpha risk factor of the vault
@@ -168,7 +167,7 @@ trait IVault<TContractState> {
     // @returns 0 if the callback was used to initialize round 1, or the total payout of the settled
     // round if it was used to settle
     fn fossil_callback(
-        ref self: TContractState, job_request: Span<felt252>, result: Span<felt252>
+        ref self: TContractState, job_request: Span<felt252>, result: Span<felt252>,
     ) -> u256;
 }
 
@@ -178,15 +177,15 @@ trait IVault<TContractState> {
 // timestamp: Upper bound timestamp of gas data used in data calculation
 // program_id: 'PITCH_LAKE_V1'
 #[derive(Copy, Drop, PartialEq)]
-struct JobRequest {
-    vault_address: ContractAddress,
-    timestamp: u64,
-    program_id: felt252,
+pub struct JobRequest {
+    pub vault_address: ContractAddress,
+    pub timestamp: u64,
+    pub program_id: felt252,
 }
 
 // Fossil job results (args, data and tolerances)
 #[derive(Copy, Drop, PartialEq)]
-struct VerifierData {
+pub struct VerifierData {
     pub reserve_price_start_timestamp: u64,
     pub reserve_price_end_timestamp: u64,
     pub reserve_price: felt252,
@@ -199,10 +198,10 @@ struct VerifierData {
 }
 
 #[derive(Default, Copy, Drop, Serde, PartialEq, starknet::Store)]
-struct L1Data {
-    twap: u256,
-    max_return: u128,
-    reserve_price: u256,
+pub struct L1Data {
+    pub twap: u256,
+    pub max_return: u128,
+    pub reserve_price: u256,
 }
 
 
@@ -275,8 +274,8 @@ impl SerdeVerifierData of Serde<VerifierData> {
                 twap_result,
                 max_return_start_timestamp,
                 max_return_end_timestamp,
-                max_return
-            }
+                max_return,
+            },
         )
     }
 }

--- a/src/vault/interface.cairo
+++ b/src/vault/interface.cairo
@@ -12,6 +12,8 @@ struct ConstructorArgs {
     round_transition_duration: u64,
     auction_duration: u64,
     round_duration: u64,
+    program_id: felt252,
+    proving_delay: u64,
 }
 
 // The interface for the vault contract
@@ -48,6 +50,13 @@ trait IVault<TContractState> {
 
     // @return The contract address of the option round
     fn get_round_address(self: @TContractState, option_round_id: u64) -> ContractAddress;
+
+    // @return This vault's program ID
+    fn get_program_id(self: @TContractState) -> felt252;
+
+    // @return The proving delay (in seconds)
+    // @dev This is about the time it takes for Fossil to be able to prove the latest block header
+    fn get_proving_delay(self: @TContractState) -> u64;
 
     /// Liquidity
 
@@ -234,26 +243,26 @@ impl SerdeVerifierData of Serde<VerifierData> {
     fn deserialize(ref serialized: Span<felt252>) -> Option<VerifierData> {
         let reserve_price_start_timestamp: u64 = (*serialized.at(0))
             .try_into()
-            .expect('failed to deser. start timestmp');
+            .expect('failed to deser. res price(0)');
         let reserve_price_end_timestamp: u64 = (*serialized.at(1))
             .try_into()
-            .expect('failed to deser. end timestamp');
+            .expect('failed to deser. res price(1)');
         let reserve_price: felt252 = *serialized.at(2);
 
         let twap_start_timestamp: u64 = (*serialized.at(3))
             .try_into()
-            .expect('failed to deser. start timestmp');
+            .expect('failed to deser. twap (0)');
         let twap_end_timestamp: u64 = (*serialized.at(4))
             .try_into()
-            .expect('failed to deser. end timestamp');
+            .expect('failed to deser. twap (1)');
         let twap_result: felt252 = *serialized.at(5);
 
         let max_return_start_timestamp: u64 = (*serialized.at(6))
             .try_into()
-            .expect('failed to deser. start timestmp');
+            .expect('failed to deser. max return(0)');
         let max_return_end_timestamp: u64 = (*serialized.at(7))
             .try_into()
-            .expect('failed to deser. end timestamp');
+            .expect('failed to deser. max return(1)');
         let max_return: felt252 = *serialized.at(8);
 
         Option::Some(

--- a/src/vault/interface.cairo
+++ b/src/vault/interface.cairo
@@ -178,15 +178,15 @@ struct JobRequest {
 // Fossil job results (args, data and tolerances)
 #[derive(Copy, Drop, PartialEq)]
 struct VerifierData {
-    pub start_timestamp: u64,
-    pub end_timestamp: u64,
+    pub reserve_price_start_timestamp: u64,
+    pub reserve_price_end_timestamp: u64,
     pub reserve_price: felt252,
+    pub twap_start_timestamp: u64,
+    pub twap_end_timestamp: u64,
     pub twap_result: felt252,
+    pub max_return_start_timestamp: u64,
+    pub max_return_end_timestamp: u64,
     pub max_return: felt252,
-    //pub floating_point_tolerance: felt252,
-//pub reserve_price_tolerance: felt252,
-//pub twap_tolerance: felt252,
-//pub gradient_tolerance: felt252,
 }
 
 #[derive(Default, Copy, Drop, Serde, PartialEq, starknet::Store)]
@@ -220,40 +220,52 @@ impl SerdeJobRequest of Serde<JobRequest> {
 // VerifierData <-> Array<felt252>
 impl SerdeVerifierData of Serde<VerifierData> {
     fn serialize(self: @VerifierData, ref output: Array<felt252>) {
-        self.start_timestamp.serialize(ref output);
-        self.end_timestamp.serialize(ref output);
+        self.reserve_price_start_timestamp.serialize(ref output);
+        self.reserve_price_end_timestamp.serialize(ref output);
         self.reserve_price.serialize(ref output);
-        //self.floating_point_tolerance.serialize(ref output);
-        //self.reserve_price_tolerance.serialize(ref output);
-        //self.twap_tolerance.serialize(ref output);
-        //self.gradient_tolerance.serialize(ref output);
+        self.twap_start_timestamp.serialize(ref output);
+        self.twap_end_timestamp.serialize(ref output);
         self.twap_result.serialize(ref output);
+        self.max_return_start_timestamp.serialize(ref output);
+        self.max_return_end_timestamp.serialize(ref output);
         self.max_return.serialize(ref output);
     }
 
     fn deserialize(ref serialized: Span<felt252>) -> Option<VerifierData> {
-        let start_timestamp: u64 = (*serialized.at(0))
+        let reserve_price_start_timestamp: u64 = (*serialized.at(0))
             .try_into()
             .expect('failed to deser. start timestmp');
-        let end_timestamp: u64 = (*serialized.at(1))
+        let reserve_price_end_timestamp: u64 = (*serialized.at(1))
             .try_into()
             .expect('failed to deser. end timestamp');
         let reserve_price: felt252 = *serialized.at(2);
-        let twap_result: felt252 = *serialized.at(3);
-        let max_return: felt252 = *serialized.at(4);
 
-        //        let twap_tolerance: felt252 = *serialized.at(5);
-        //        let gradient_tolerance: felt252 = *serialized.at(6);
+        let twap_start_timestamp: u64 = (*serialized.at(3))
+            .try_into()
+            .expect('failed to deser. start timestmp');
+        let twap_end_timestamp: u64 = (*serialized.at(4))
+            .try_into()
+            .expect('failed to deser. end timestamp');
+        let twap_result: felt252 = *serialized.at(5);
+
+        let max_return_start_timestamp: u64 = (*serialized.at(6))
+            .try_into()
+            .expect('failed to deser. start timestmp');
+        let max_return_end_timestamp: u64 = (*serialized.at(7))
+            .try_into()
+            .expect('failed to deser. end timestamp');
+        let max_return: felt252 = *serialized.at(8);
 
         Option::Some(
             VerifierData {
-                start_timestamp,
-                end_timestamp,
-                reserve_price, //                floating_point_tolerance,
-                //                reserve_price_tolerance,
-                //                twap_tolerance,
-                //                gradient_tolerance,
+                reserve_price_start_timestamp,
+                reserve_price_end_timestamp,
+                reserve_price,
+                twap_start_timestamp,
+                twap_end_timestamp,
                 twap_result,
+                max_return_start_timestamp,
+                max_return_end_timestamp,
                 max_return
             }
         )

--- a/timestamp_ranges_guide.md
+++ b/timestamp_ranges_guide.md
@@ -1,0 +1,60 @@
+# Timestamp Ranges for L1 Data Validation
+
+This guide explains how to calculate the correct timestamp ranges to pass the L1 data validation checks in the vault contract.
+
+## Required View Functions
+
+The vault contract provides these view functions to get the necessary components:
+
+- `get_round_duration()` - Returns the round duration (line 266)
+- `get_current_round_id()` - Returns the current round ID (line 283)  
+- `get_round_dispatcher(round_id)` - Gets a round dispatcher for round-specific functions (line 800)
+
+From the round dispatcher, you can call:
+- `get_option_settlement_date()` - For running rounds
+- `get_deployment_date()` - For non-running rounds
+
+## Calculating Expected Ranges
+
+```cairo
+// Get the components
+let round_duration = vault.get_round_duration();
+let current_round_id = vault.get_current_round_id();
+let current_round = vault.get_round_dispatcher(current_round_id);
+
+// Determine upper bound based on round state
+let upper_bound = if round_state == OptionRoundState::Running {
+    current_round.get_option_settlement_date()
+} else {
+    current_round.get_deployment_date()  
+};
+
+// Calculate the expected ranges
+let twap_lower_bound = upper_bound - round_duration;
+let reserve_price_lower_bound = upper_bound - (3 * round_duration);
+let max_return_lower_bound = reserve_price_lower_bound;
+
+// All end timestamps should equal upper_bound
+let expected_end_timestamp = upper_bound;
+```
+
+## Expected Values for L1 Data
+
+Your L1 data should have these timestamp values:
+
+| Field | Expected Value |
+|-------|----------------|
+| `twap_start_timestamp` | `upper_bound - round_duration` |
+| `reserve_price_start_timestamp` | `upper_bound - (3 * round_duration)` |
+| `max_return_start_timestamp` | `upper_bound - (3 * round_duration)` |
+| `twap_end_timestamp` | `upper_bound` |
+| `reserve_price_end_timestamp` | `upper_bound` |
+| `max_return_end_timestamp` | `upper_bound` |
+
+## Notes
+
+- For **running rounds**: `upper_bound` = option settlement date
+- For **non-running rounds**: `upper_bound` = deployment date  
+- Reserve price and max return have the same lower bound (3x round duration before upper bound)
+- All end timestamps must equal the upper bound
+- TWAP has a shorter window (1x round duration before upper bound)


### PR DESCRIPTION
This PR utilizes the latest version of the data forwarded from the Pitchlake Verifier. With these changes, the data from the verifier can be fully validated before used. 

+ program_id (felt) & proving_delay (u64) vars added to vault constructor args (at the end) cc @dhruv035 

@ametel01 I have also added an "@proposal" comment at the very end of the ./src/vault/interface.cairo file. This proposal is not required, the current contract state is fine. This proposal just highlights how we could re-organize/group/re-structure the data sent from Verifier to Vault. Again, this propoal is not needed like the previous ones, just an idea for possibly enhancing readability.